### PR TITLE
feat(analytics): add Umami self-hosted tracking

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -153,6 +153,13 @@ const fullTitle = title === SITE_TITLE ? title : `${title} | ${SITE_TITLE}`
 <meta name="twitter:image" content={imageUrl} />
 <meta name="twitter:image:alt" content={title} />
 
+<!-- Umami Analytics (self-hosted, privacy-first) -->
+<script
+  defer
+  src="https://analytics.sip-protocol.org/script.js"
+  data-website-id="f1b2e6c9-c591-4252-b76e-71084bf9e30c"
+></script>
+
 <!-- JSON-LD slot (for structured data) -->
 <slot name="json-ld" />
 


### PR DESCRIPTION
## Summary

- Deploy self-hosted Umami analytics at `analytics.sip-protocol.org`
- Add tracking script to blog BaseHead.astro
- Privacy-first, GDPR-compliant, no cookies

## Infrastructure

| Component | Details |
|-----------|---------|
| Umami | Port 5010, Docker |
| PostgreSQL | Alpine 15, persistent volume |
| Domain | analytics.sip-protocol.org |
| SSL | Let's Encrypt (auto-renew) |

## Website IDs Created

| Site | ID |
|------|-----|
| SIP Blog | `f1b2e6c9-c591-4252-b76e-71084bf9e30c` |
| SIP Docs | `5a56a99e-502d-499e-a282-c46a20e556e0` |
| SIP Website | `ad016e04-ff09-4cf0-be5d-6c4de4bda1b9` |
| SIP App | `4ccd6b5d-58c5-4f87-b070-0b182e5e573a` |

## Unlocks

- sip-website#134 - Add tracking to marketing site
- docs-sip#28 - Add tracking to documentation

Closes #79

---

Generated with [Claude Code](https://claude.com/claude-code)