### PR TITLE
fix(deps): override diff to ^8.0.3 for security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
     "remark-gfm": "^4.0.1",
     "sharp": "^0.34.3"
   },
+  "pnpm": {
+    "overrides": {
+      "diff": "^8.0.3"
+    }
+  },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.19",
     "@typescript-eslint/eslint-plugin": "^8.53.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  diff: ^8.0.3
+
 importers:
 
   .:
@@ -1234,8 +1237,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  diff@5.2.0:
-    resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
+  diff@8.0.3:
+    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
 
   dlv@1.1.3:
@@ -3535,7 +3538,7 @@ snapshots:
       debug: 4.4.3
       deterministic-object-hash: 2.0.2
       devalue: 5.6.1
-      diff: 5.2.0
+      diff: 8.0.3
       dlv: 1.1.3
       dset: 3.1.4
       es-module-lexer: 1.7.0
@@ -3815,7 +3818,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  diff@5.2.0: {}
+  diff@8.0.3: {}
 
   dlv@1.1.3: {}
 


### PR DESCRIPTION
## Summary

Fixes Dependabot security alert for `diff` package vulnerability.

## Problem

- Dependabot couldn't auto-update because `astro` pins `diff@^5.2.0`
- Security fix requires `diff@8.0.3` (major version jump)
- Vulnerability: DoS in `parsePatch`/`applyPatch` (LOW severity)

## Solution

Using pnpm overrides to force the patched version:

```json
"pnpm": {
  "overrides": {
    "diff": "^8.0.3"
  }
}
```

## Test Plan

- [x] `pnpm install` succeeds
- [x] `pnpm build` succeeds (102 pages indexed)
- [x] `pnpm why diff` shows 8.0.3