### PR TITLE
fix: remove unused err variable in ShareButtons

### DIFF
--- a/src/components/ShareButtons.astro
+++ b/src/components/ShareButtons.astro
@@ -106,7 +106,7 @@ const linkedinUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encod
           nativeBtn.addEventListener('click', async () => {
             try {
               await navigator.share({ title, url })
-            } catch (err) {
+            } catch {
               // User cancelled or error - silently ignore
             }
           })


### PR DESCRIPTION
## Summary
- Remove unused `err` variable in catch block (ShareButtons.astro:109)
- Fixes eslint `@typescript-eslint/no-unused-vars` error

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm build` passes