### PR TITLE
fix(docker): use IPv4 for healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - HOST=0.0.0.0
       - PORT=4321
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4321/"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:4321/"]
       interval: 30s
       timeout: 3s
       retries: 3


### PR DESCRIPTION
## Summary
Fix healthcheck failing due to IPv6 resolution issue on Alpine containers.

## Change
```diff
- http://localhost:4321/
+ http://127.0.0.1:4321/
```

## Problem
`wget` on Alpine tries IPv6 (`[::1]`) first when resolving `localhost`, which fails because the Node.js server only listens on IPv4.

## Test plan
- [x] Deploy will verify healthcheck passes