### PR TITLE
Phase 4a: Sipher Vault devnet beta launch post

### DIFF
--- a/public/images/sipher-vault/architecture-diagram.svg
+++ b/public/images/sipher-vault/architecture-diagram.svg
@@ -1,0 +1,163 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500" width="800" height="500" role="img" aria-labelledby="vault-diagram-title">
+  <title id="vault-diagram-title">Sipher Vault: deposit → withdraw_private → CPI → claim flow</title>
+  <defs>
+    <linearGradient id="vaultGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#6366f1;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#8b5cf6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="sipGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0ea5e9;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#10b981;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0f0f1a;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1a1a2e;stop-opacity:1" />
+    </linearGradient>
+    <marker id="arrowPurple" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#8b5cf6"/>
+    </marker>
+    <marker id="arrowGreen" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#10b981"/>
+    </marker>
+    <marker id="arrowBlue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#0ea5e9"/>
+    </marker>
+    <marker id="arrowGray" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#64748b"/>
+    </marker>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="2" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="500" fill="url(#bgGrad)" rx="12"/>
+  <rect width="800" height="500" fill="none" stroke="#2d2d4e" stroke-width="1" rx="12"/>
+
+  <!-- Title -->
+  <text x="400" y="32" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="600" fill="#a5b4fc" letter-spacing="0.05em">SIPHER VAULT — DEPOSIT / WITHDRAW / CLAIM FLOW</text>
+
+  <!-- ══════════════════════════════════════════ -->
+  <!-- LEFT: Sender Wallet -->
+  <!-- ══════════════════════════════════════════ -->
+  <rect x="20" y="180" width="130" height="80" rx="8" fill="#1e1b4b" stroke="#6366f1" stroke-width="1.5"/>
+  <text x="85" y="214" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#c7d2fe">Sender</text>
+  <text x="85" y="230" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#c7d2fe">Wallet</text>
+  <!-- wallet icon paths -->
+  <rect x="66" y="238" width="38" height="12" rx="2" fill="none" stroke="#6366f1" stroke-width="1.2"/>
+  <rect x="78" y="235" width="14" height="4" rx="1" fill="#6366f1"/>
+  <circle cx="79" cy="244" r="2" fill="#6366f1"/>
+
+  <!-- ══════════════════════════════════════════ -->
+  <!-- CENTER: Sipher Vault box (tall) -->
+  <!-- ══════════════════════════════════════════ -->
+  <rect x="200" y="60" width="260" height="370" rx="10" fill="#12122a" stroke="#6366f1" stroke-width="2"/>
+  <rect x="200" y="60" width="260" height="40" rx="10" fill="url(#vaultGrad)"/>
+  <rect x="200" y="88" width="260" height="12" rx="0" fill="url(#vaultGrad)"/>
+  <text x="330" y="87" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="700" fill="#ffffff" filter="url(#glow)">SIPHER VAULT</text>
+  <text x="330" y="107" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#a5b4fc">S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB</text>
+
+  <!-- VaultConfig PDA sub-box -->
+  <rect x="218" y="122" width="224" height="52" rx="6" fill="#1e1b4b" stroke="#4338ca" stroke-width="1"/>
+  <text x="330" y="142" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#a5b4fc">VaultConfig PDA</text>
+  <text x="330" y="157" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9.5" fill="#6366f1">fee_bps=10  refund_timeout=86400s</text>
+  <text x="330" y="170" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9.5" fill="#6366f1">paused=false</text>
+
+  <!-- DepositRecord PDA sub-box -->
+  <rect x="218" y="186" width="224" height="62" rx="6" fill="#1e1b4b" stroke="#7c3aed" stroke-width="1"/>
+  <text x="330" y="206" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#c4b5fd">DepositRecord PDA</text>
+  <text x="330" y="221" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9.5" fill="#8b5cf6">seeds: [b"deposit", user, mint, nonce]</text>
+  <text x="330" y="235" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9.5" fill="#8b5cf6">amount, fee_collected, timestamp</text>
+  <text x="330" y="248" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" fill="#64748b">refund available after 24h if unclaimed</text>
+
+  <!-- Authority signs withdraw_private section -->
+  <rect x="218" y="262" width="224" height="70" rx="6" fill="#0f1a2e" stroke="#0ea5e9" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="330" y="282" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#7dd3fc">Authority Signs</text>
+  <text x="330" y="296" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#7dd3fc">withdraw_private</text>
+  <text x="330" y="312" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9.5" fill="#0ea5e9">NOT the sender — separate keypair</text>
+  <text x="330" y="325" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9.5" fill="#0ea5e9">breaks sender-recipient link on-chain</text>
+
+  <!-- CPI arrow inside vault pointing down to sip_privacy -->
+  <line x1="330" y1="342" x2="330" y2="388" stroke="#10b981" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrowGreen)"/>
+  <text x="356" y="368" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9.5" fill="#10b981">CPI</text>
+
+  <!-- sip_privacy CPI call sub-box -->
+  <rect x="218" y="390" width="224" height="30" rx="6" fill="#0d1f16" stroke="#10b981" stroke-width="1"/>
+  <text x="330" y="406" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9.5" font-weight="600" fill="#34d399">create_transfer_announcement</text>
+  <text x="330" y="419" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="8.5" fill="#6ee7b7">creates transfer_record PDA in sip_privacy</text>
+
+  <!-- ══════════════════════════════════════════ -->
+  <!-- BOTTOM-CENTER: sip_privacy program -->
+  <!-- ══════════════════════════════════════════ -->
+  <rect x="230" y="446" width="200" height="42" rx="8" fill="#0d1f16" stroke="#10b981" stroke-width="1.5"/>
+  <text x="330" y="464" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="700" fill="#10b981">sip_privacy program</text>
+  <text x="330" y="479" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="8.5" fill="#6ee7b7">S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at</text>
+
+  <!-- ══════════════════════════════════════════ -->
+  <!-- RIGHT: Stealth Recipient ATA + Recipient Wallet -->
+  <!-- ══════════════════════════════════════════ -->
+  <!-- Stealth ATA -->
+  <rect x="580" y="155" width="140" height="65" rx="8" fill="#1a1a2e" stroke="#8b5cf6" stroke-width="1.5"/>
+  <text x="650" y="179" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#c4b5fd">Stealth</text>
+  <text x="650" y="194" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#c4b5fd">Recipient ATA</text>
+  <text x="650" y="211" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="8.5" fill="#7c3aed">one-time address — not linked to sender</text>
+
+  <!-- Recipient Wallet (claim) -->
+  <rect x="590" y="280" width="120" height="70" rx="8" fill="#1e1b4b" stroke="#6366f1" stroke-width="1.5"/>
+  <text x="650" y="308" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#c7d2fe">Recipient</text>
+  <text x="650" y="323" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9.5" fill="#a5b4fc">scans with viewing key</text>
+  <text x="650" y="337" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9.5" fill="#a5b4fc">calls claim</text>
+
+  <!-- ══════════════════════════════════════════ -->
+  <!-- ARROWS -->
+  <!-- ══════════════════════════════════════════ -->
+
+  <!-- 1. Sender → Vault: deposit(amount) -->
+  <line x1="152" y1="220" x2="196" y2="220" stroke="#6366f1" stroke-width="2" marker-end="url(#arrowPurple)"/>
+  <rect x="150" y="195" width="50" height="18" rx="3" fill="#0f0f1a"/>
+  <text x="175" y="206" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" fill="#818cf8">deposit</text>
+  <text x="175" y="217" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="8.5" fill="#6366f1">(amount)</text>
+
+  <!-- 2. Vault → Stealth ATA: withdraw_private -->
+  <line x1="462" y1="295" x2="577" y2="225" stroke="#0ea5e9" stroke-width="2" marker-end="url(#arrowBlue)"/>
+  <rect x="476" y="260" width="80" height="28" rx="3" fill="#0f0f1a"/>
+  <text x="516" y="274" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" font-weight="600" fill="#7dd3fc">withdraw_</text>
+  <text x="516" y="285" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" font-weight="600" fill="#7dd3fc">private</text>
+
+  <!-- 3. Stealth ATA → Recipient (claim) -->
+  <line x1="650" y1="220" x2="650" y2="278" stroke="#a78bfa" stroke-width="2" marker-end="url(#arrowGray)"/>
+  <text x="660" y="254" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9.5" fill="#8b5cf6">claim</text>
+
+  <!-- 4. sip_privacy ← CPI (from vault/withdraw_private, vertical line from bottom of vault box) -->
+  <!-- Arrow from sip_privacy sub-box (bottom of vault) down to the sip_privacy program rect -->
+  <line x1="330" y1="422" x2="330" y2="444" stroke="#10b981" stroke-width="2" marker-end="url(#arrowGreen)"/>
+
+  <!-- ══════════════════════════════════════════ -->
+  <!-- PRIVACY GUARANTEE ANNOTATION -->
+  <!-- ══════════════════════════════════════════ -->
+  <rect x="20" y="370" width="158" height="68" rx="6" fill="#0d1a0d" stroke="#10b981" stroke-width="1" stroke-dasharray="3,3"/>
+  <text x="99" y="390" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="700" fill="#34d399">Privacy Guarantee</text>
+  <text x="99" y="406" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" fill="#6ee7b7">Sender wallet and recipient</text>
+  <text x="99" y="419" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" fill="#6ee7b7">viewing key are NEVER</text>
+  <text x="99" y="432" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" fill="#6ee7b7">directly linked on-chain</text>
+
+  <!-- ══════════════════════════════════════════ -->
+  <!-- LEGEND -->
+  <!-- ══════════════════════════════════════════ -->
+  <rect x="580" y="375" width="200" height="100" rx="6" fill="#12122a" stroke="#2d2d4e" stroke-width="1"/>
+  <text x="680" y="393" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="700" fill="#94a3b8">Legend</text>
+  <line x1="593" y1="405" x2="620" y2="405" stroke="#6366f1" stroke-width="2"/>
+  <text x="627" y="409" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" fill="#a5b4fc">User action</text>
+  <line x1="593" y1="421" x2="620" y2="421" stroke="#0ea5e9" stroke-width="2"/>
+  <text x="627" y="425" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" fill="#a5b4fc">Authority action</text>
+  <line x1="593" y1="437" x2="620" y2="437" stroke="#10b981" stroke-width="2"/>
+  <text x="627" y="441" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" fill="#a5b4fc">CPI (cross-program)</text>
+  <line x1="593" y1="453" x2="620" y2="453" stroke="#8b5cf6" stroke-width="2"/>
+  <text x="627" y="457" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" fill="#a5b4fc">Recipient action</text>
+  <line x1="593" y1="469" x2="620" y2="469" stroke="#0ea5e9" stroke-width="2" stroke-dasharray="4,3"/>
+  <text x="627" y="473" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" fill="#a5b4fc">Authority-only zone</text>
+</svg>

--- a/src/content/blog/sipher-vault-devnet-beta-open.md
+++ b/src/content/blog/sipher-vault-devnet-beta-open.md
@@ -1,0 +1,179 @@
+---
+title: 'Sipher Vault: Devnet Beta is Open'
+description: 'Solana privacy primitive in public devnet beta — break sender-to-stealth-recipient correlation via authority-signed CPI to sip_privacy.'
+pubDate: 'May 6 2026'
+category: 'announcements'
+tags: ['sipher', 'vault', 'solana', 'privacy', 'devnet', 'beta', 'cpi', 'stealth-addresses']
+draft: false
+author: 'SIP Protocol Team'
+tldr: 'Sipher Vault devnet beta is open. It closes the sender-side privacy gap stealth addresses alone cannot fix — authority-signed CPI to sip_privacy breaks the on-chain link between sender wallet and stealth recipient.'
+keyTakeaways:
+  - 'Sipher Vault interposes an authority between sender and stealth recipient, eliminating on-chain TX correlation'
+  - 'withdraw_private fires a CPI to sip_privacy.create_transfer_announcement — recipient discovery via viewing key, no out-of-band signaling'
+  - '9 instructions across three signer roles: deploy bootstrap, user actions, authority operations'
+  - 'Mainnet ships only after hybrid time-plus-metrics gate criteria are satisfied — criteria are public and tracked'
+targetAudience: 'Developers evaluating Solana privacy infrastructure, testers from the Solana community'
+prerequisites:
+  - 'Familiarity with Solana program model (PDAs, CPI, ATAs)'
+  - 'Basic understanding of stealth addresses and viewing keys'
+relatedPosts:
+  - 'sip-roadmap-2026-explained'
+  - 'stealth-addresses-eip-5564'
+  - 'viewing-keys-compliance'
+---
+
+Sipher Vault is now open for public testing on Solana devnet.
+
+This post covers what the vault does, why it exists as a distinct primitive from the underlying stealth address and commitment scheme, how the deposit-to-claim flow works at the instruction level, and the exact criteria that gate the subsequent mainnet deployment. If you are evaluating Solana privacy infrastructure or want to stress-test the system before it handles real funds, this is for you.
+
+---
+
+## What Is Sipher Vault?
+
+Sipher Vault is a Solana Anchor program that acts as a privacy primitive for token transfers to stealth recipients. A user deposits SPL tokens into the vault, and an authority — operating a separate keypair from the sender — issues the outbound transfer to the stealth recipient ATA. The authority then fires a cross-program invocation into `sip_privacy` to create an on-chain transfer record, which the recipient discovers via viewing key without any out-of-band signaling.
+
+The program ID is `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB`. That same ID will be the mainnet program ID — there is no address migration between clusters.
+
+---
+
+## Why a Vault for Privacy?
+
+The question worth addressing first: stealth addresses already hide the recipient. Pedersen commitments hide the amount. Viewing keys give recipients the ability to discover funds cryptographically. What is missing?
+
+The sender side.
+
+When a wallet sends tokens directly to a stealth address — even a correctly derived, one-time stealth address — the originating transaction is fully visible on-chain. The sender's account, the timing, and the amount all appear in the TX history. Anyone watching that wallet can observe that funds left it and infer the recipient from the ATA that received them, regardless of how opaque that ATA's derivation looks to an outside observer. This is a correlation attack at the TX graph level: if you know the sender's wallet and you see a transfer to an address with no prior activity, you can fingerprint the stealth address as theirs.
+
+The vault closes that gap. By interposing an authority between sender and recipient:
+
+- The sender's transaction goes *into* the vault, not to the recipient
+- The authority's transaction goes *from* the vault to the stealth recipient
+- The on-chain trace shows: sender → vault; vault → stealth ATA
+- There is no direct sender → recipient edge in the TX graph
+
+Couple this with `sip_privacy.create_transfer_announcement` — the CPI the vault fires on `withdraw_private` — and the recipient can scan for their funds using their viewing key without the sender having to tell them anything. The `transfer_record` PDA created in `sip_privacy` (program `S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at`, deployed mainnet March 7 2026) is the discovery mechanism.
+
+This is what "complete" sender-side privacy means on Solana.
+
+---
+
+## Architecture
+
+![Sipher Vault architecture flow](/images/sipher-vault/architecture-diagram.svg)
+
+The flow, step by step:
+
+**1. Deposit.** The user calls `vault.deposit(amount)`. The vault creates a `DepositRecord` PDA seeded from `[b"deposit", user_pubkey, mint, nonce]`. The PDA stores the deposited amount, the collected fee (computed at `fee_bps = 10` of amount), and the deposit timestamp. Tokens move from the user's ATA to the vault's ATA for that mint.
+
+**2. Authority-signed withdrawal.** The authority — a separate keypair from the sender — calls `vault.withdraw_private`. This instruction:
+- Verifies the `DepositRecord` is not yet claimed
+- Computes the net amount after fee deduction
+- Transfers tokens from the vault ATA to the stealth recipient's ATA (using `CreateIdempotent` + `TransferChecked`)
+- Fires a CPI to `sip_privacy.create_transfer_announcement`, which creates a `transfer_record` PDA in the `sip_privacy` program state
+
+**3. Recipient discovery.** The recipient scans using their viewing key. The `transfer_record` PDA on `sip_privacy` is the on-chain signal. No out-of-band communication is required between sender and recipient.
+
+**4. Claim.** Once the recipient identifies the stealth ATA containing their funds, they call `claim` on `sip_privacy` to sweep the balance into their regular wallet.
+
+The `DepositRecord` and `VaultConfig` PDAs live on the vault program. The `transfer_record` PDA lives on `sip_privacy`. The authority is the bridge between them.
+
+> **Key property:** The sender's wallet and the recipient's viewing key are never directly linked on-chain. The authority signs the outbound transfer, so the on-chain TX graph shows only vault → stealth ATA, not sender → stealth ATA.
+
+---
+
+## The 9 Instructions
+
+The vault has 9 instructions across three signer roles: deploy-time bootstrap (called once per cluster), user actions, and authority operations.
+
+| Instruction | Signer | Description |
+|---|---|---|
+| `initialize` | Deploy authority | Creates the `VaultConfig` PDA: fee bps, refund timeout, authority pubkey. Called once at program deployment. |
+| `create_vault_token` | Authority | Initializes a vault-side ATA for a given mint before any deposits of that token can be accepted. |
+| `create_fee_token` | Authority | Initializes the fee-collection ATA for a given mint. |
+| `deposit` | User | User deposits SPL tokens; creates a `DepositRecord` PDA holding deposit metadata, fee, and timestamp. |
+| `withdraw_private` | Authority | Transfers to stealth recipient ATA and CPIs into `sip_privacy.create_transfer_announcement` to create the on-chain transfer record. Emits `VaultWithdrawEvent`. |
+| `refund` | User | User reclaims their deposit after the 24-hour refund timeout has elapsed. Available if the authority has not yet issued `withdraw_private`. |
+| `authority_refund` | Authority | Authority refunds a deposit on the user's behalf. The 24-hour timeout applies equally — it is not bypassed for the authority. |
+| `collect_fee` | Authority | Authority collects accumulated fees from the fee ATA. |
+| `set_paused` | Authority | Pauses or unpauses the program. When paused, `deposit` returns `ProgramPaused (0x1770)`. Emits `VaultPausedEvent { authority, paused, timestamp }` for off-chain monitoring. |
+
+The `set_paused` instruction, combined with SENTINEL — the LLM-backed security analyst that monitors vault state — gives the authority a tested emergency lever. The pause mechanism was exercised during Phase 3 rehearsal: deposit-during-pause correctly reverts with `ProgramPaused 0x1770` at `lib.rs:92`, and the vault returned to live state in under 20 seconds.
+
+---
+
+## Try It on Devnet
+
+Testing the vault requires devnet SOL and an SPL token. Here is the minimal path:
+
+**1. Get devnet SOL.**
+Use the Solana CLI airdrop (`solana airdrop 2 --url devnet`) or the faucet at https://faucet.solana.com.
+
+**2. Open Sipher.**
+Navigate to https://sipher.sip-protocol.org. An amber banner at the top of the page confirms you are on the devnet configuration. If no banner is visible, the environment variable `SIPHER_NETWORK` may be misconfigured — file an issue.
+
+**3. Connect your wallet.**
+Phantom, Backpack, and Solflare are supported via wallet-standard. The vault is cluster-aware and will reject mainnet wallet configurations.
+
+**4. Deposit a small wSOL amount.**
+Use a round amount for simplicity. The vault will compute the fee (10 bps) and create your `DepositRecord` PDA. Note the deposit signature — it is useful if you need to file a bug report.
+
+**5. Generate or specify a stealth recipient address.**
+If testing the full flow solo, derive a stealth recipient address from a second keypair's viewing and spending keys using the SIP SDK. If testing only the deposit path, the authority will supply the recipient.
+
+**6. Authority issues withdraw_private.**
+This step is currently authority-operated (not self-service). The authority will process devnet withdrawals during the beta period. On mainnet, this operation is automated.
+
+**7. Recipient scans and claims.**
+The recipient uses their viewing key to scan for the `transfer_record` PDA in `sip_privacy`, then calls `claim`.
+
+If any step fails — TX reverts, UX confusion, wallet handshake issues, or unexpected behavior — file an issue at https://github.com/sip-protocol/sipher/issues. Include the transaction signature. That TX signature is the fastest path to root cause.
+
+---
+
+## Gate Criteria for Mainnet
+
+Mainnet deployment is conditioned on passing a hybrid time-plus-metrics gate. These criteria are not aspirational targets — they are the inputs to an automated gate-check script. We are publishing them here as a public commitment to what "ready" means.
+
+The gate requires all of the following:
+
+- **Time soak:** At least 3 days have elapsed since public devnet launch
+- **Deposit coverage:** At least 5 successful deposits from at least 3 distinct non-team wallets
+- **Withdrawal coverage:** At least 3 successful `withdraw_private` calls from at least 2 distinct non-team wallets
+- **Refund coverage:** At least 1 successful `authority_refund` — the Phase 3 SENTINEL refund evidence already satisfies this criterion. The refund TX `4YHpsgZpXhvYd9EsCRBjfkhUDgGGitAM3R4gu9EqivtKwMRtamkMN2BUumdZTPbaRt3sQb4mp8QW2YFVZJ2EnYDz` ([Solscan devnet](https://solscan.io/tx/4YHpsgZpXhvYd9EsCRBjfkhUDgGGitAM3R4gu9EqivtKwMRtamkMN2BUumdZTPbaRt3sQb4mp8QW2YFVZJ2EnYDz?cluster=devnet)) confirms the SENTINEL-gated authority refund path works end-to-end. The Phase 3 evidence is committed at `docs/sentinel/evidence/devnet-refund-2026-05-05.json`.
+- **Zero unexplained reverts:** Any revert that cannot be classified as user error within one hour of a human reviewing the failed TX invalidates the gate
+- **Zero authority interventions:** No `set_paused`, no manual fee adjustments, no state corrections from the authority side during the soak window
+
+SENTINEL — documented at https://docs.sip-protocol.org/sipher/sentinel/overview/ — monitors vault state and classifies anomalies in real time. Its advisory mode is live on the current VPS deployment. The gate-check script queries SENTINEL's classification log as part of the "zero unexplained reverts" check.
+
+If the gate has not been passed by Day 7, we run a bug-fix sweep, then reassess. The assessment options are: extend the soak, lower specific numeric thresholds with justification, ship mainnet anyway with disclosed gaps, or defer mainnet to the following sprint. No option is off the table — quality gates exist to surface real information, not to enforce arbitrary ceremony.
+
+---
+
+## What Is Identical Between Devnet and Mainnet
+
+Everything that matters cryptographically and operationally:
+
+- The program binary — same compiled artifact, same instruction logic
+- The 24-hour refund timeout enforcement
+- The `fee_bps = 10` computation
+- The CPI to `sip_privacy.create_transfer_announcement`
+- The event emission (`VaultWithdrawEvent`, `VaultPausedEvent`)
+- The vanity program ID: `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB` on both clusters
+
+What changes on mainnet: real tokens, a production-tier RPC endpoint, and the BetaBanner disappears from the Sipher UI. The `SIPHER_NETWORK` environment variable flips from `devnet` to `mainnet` on the VPS, and `docker compose up -d sipher` propagates the change. That is the full mainnet deployment operation, after the gate-check script returns green.
+
+---
+
+## What Comes Next
+
+After the devnet gate passes, we ship mainnet. The announcement will include the beta period TX data as evidence — actual deposit counts, withdrawal counts, distinct wallet participation, and the zero-revert record.
+
+Beyond mainnet, M19 addresses claim linkability — a known gap in the current design where a recipient who repeatedly claims from the same stealth address accumulates a fingerprint. M19 is a separate engineering track, not a blocker for the vault mainnet launch. It is tracked independently.
+
+---
+
+**Try it:** https://sipher.sip-protocol.org
+
+**Technical docs (SENTINEL):** https://docs.sip-protocol.org/sipher/sentinel/overview/
+
+**File a bug:** https://github.com/sip-protocol/sipher/issues

--- a/src/content/blog/sipher-vault-devnet-beta-open.md
+++ b/src/content/blog/sipher-vault-devnet-beta-open.md
@@ -3,7 +3,17 @@ title: 'Sipher Vault: Devnet Beta is Open'
 description: 'Solana privacy primitive in public devnet beta — break sender-to-stealth-recipient correlation via authority-signed CPI to sip_privacy.'
 pubDate: 'May 6 2026'
 category: 'announcements'
-tags: ['sipher', 'vault', 'solana', 'privacy', 'devnet', 'beta', 'cpi', 'stealth-addresses']
+tags:
+  [
+    'sipher',
+    'vault',
+    'solana',
+    'privacy',
+    'devnet',
+    'beta',
+    'cpi',
+    'stealth-addresses',
+  ]
 draft: false
 author: 'SIP Protocol Team'
 tldr: 'Sipher Vault devnet beta is open. It closes the sender-side privacy gap stealth addresses alone cannot fix — authority-signed CPI to sip_privacy breaks the on-chain link between sender wallet and stealth recipient.'
@@ -46,8 +56,8 @@ When a wallet sends tokens directly to a stealth address — even a correctly de
 
 The vault closes that gap. By interposing an authority between sender and recipient:
 
-- The sender's transaction goes *into* the vault, not to the recipient
-- The authority's transaction goes *from* the vault to the stealth recipient
+- The sender's transaction goes _into_ the vault, not to the recipient
+- The authority's transaction goes _from_ the vault to the stealth recipient
 - The on-chain trace shows: sender → vault; vault → stealth ATA
 - There is no direct sender → recipient edge in the TX graph
 
@@ -66,6 +76,7 @@ The flow, step by step:
 **1. Deposit.** The user calls `vault.deposit(amount)`. The vault creates a `DepositRecord` PDA seeded from `[b"deposit", user_pubkey, mint, nonce]`. The PDA stores the deposited amount, the collected fee (computed at `fee_bps = 10` of amount), and the deposit timestamp. Tokens move from the user's ATA to the vault's ATA for that mint.
 
 **2. Authority-signed withdrawal.** The authority — a separate keypair from the sender — calls `vault.withdraw_private`. This instruction:
+
 - Verifies the `DepositRecord` is not yet claimed
 - Computes the net amount after fee deduction
 - Transfers tokens from the vault ATA to the stealth recipient's ATA (using `CreateIdempotent` + `TransferChecked`)
@@ -85,17 +96,17 @@ The `DepositRecord` and `VaultConfig` PDAs live on the vault program. The `trans
 
 The vault has 9 instructions across three signer roles: deploy-time bootstrap (called once per cluster), user actions, and authority operations.
 
-| Instruction | Signer | Description |
-|---|---|---|
-| `initialize` | Deploy authority | Creates the `VaultConfig` PDA: fee bps, refund timeout, authority pubkey. Called once at program deployment. |
-| `create_vault_token` | Authority | Initializes a vault-side ATA for a given mint before any deposits of that token can be accepted. |
-| `create_fee_token` | Authority | Initializes the fee-collection ATA for a given mint. |
-| `deposit` | User | User deposits SPL tokens; creates a `DepositRecord` PDA holding deposit metadata, fee, and timestamp. |
-| `withdraw_private` | Authority | Transfers to stealth recipient ATA and CPIs into `sip_privacy.create_transfer_announcement` to create the on-chain transfer record. Emits `VaultWithdrawEvent`. |
-| `refund` | User | User reclaims their deposit after the 24-hour refund timeout has elapsed. Available if the authority has not yet issued `withdraw_private`. |
-| `authority_refund` | Authority | Authority refunds a deposit on the user's behalf. The 24-hour timeout applies equally — it is not bypassed for the authority. |
-| `collect_fee` | Authority | Authority collects accumulated fees from the fee ATA. |
-| `set_paused` | Authority | Pauses or unpauses the program. When paused, `deposit` returns `ProgramPaused (0x1770)`. Emits `VaultPausedEvent { authority, paused, timestamp }` for off-chain monitoring. |
+| Instruction          | Signer           | Description                                                                                                                                                                  |
+| -------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `initialize`         | Deploy authority | Creates the `VaultConfig` PDA: fee bps, refund timeout, authority pubkey. Called once at program deployment.                                                                 |
+| `create_vault_token` | Authority        | Initializes a vault-side ATA for a given mint before any deposits of that token can be accepted.                                                                             |
+| `create_fee_token`   | Authority        | Initializes the fee-collection ATA for a given mint.                                                                                                                         |
+| `deposit`            | User             | User deposits SPL tokens; creates a `DepositRecord` PDA holding deposit metadata, fee, and timestamp.                                                                        |
+| `withdraw_private`   | Authority        | Transfers to stealth recipient ATA and CPIs into `sip_privacy.create_transfer_announcement` to create the on-chain transfer record. Emits `VaultWithdrawEvent`.              |
+| `refund`             | User             | User reclaims their deposit after the 24-hour refund timeout has elapsed. Available if the authority has not yet issued `withdraw_private`.                                  |
+| `authority_refund`   | Authority        | Authority refunds a deposit on the user's behalf. The 24-hour timeout applies equally — it is not bypassed for the authority.                                                |
+| `collect_fee`        | Authority        | Authority collects accumulated fees from the fee ATA.                                                                                                                        |
+| `set_paused`         | Authority        | Pauses or unpauses the program. When paused, `deposit` returns `ProgramPaused (0x1770)`. Emits `VaultPausedEvent { authority, paused, timestamp }` for off-chain monitoring. |
 
 The `set_paused` instruction, combined with SENTINEL — the LLM-backed security analyst that monitors vault state — gives the authority a tested emergency lever. The pause mechanism was exercised during Phase 3 rehearsal: deposit-during-pause correctly reverts with `ProgramPaused 0x1770` at `lib.rs:92`, and the vault returned to live state in under 20 seconds.
 

--- a/src/content/blog/sipher-vault-devnet-beta-open.md
+++ b/src/content/blog/sipher-vault-devnet-beta-open.md
@@ -24,7 +24,7 @@ relatedPosts:
 
 Sipher Vault is now open for public testing on Solana devnet.
 
-This post covers what the vault does, why it exists as a distinct primitive from the underlying stealth address and commitment scheme, how the deposit-to-claim flow works at the instruction level, and the exact criteria that gate the subsequent mainnet deployment. If you are evaluating Solana privacy infrastructure or want to stress-test the system before it handles real funds, this is for you.
+This post covers what the vault does, why it exists as a distinct primitive from the underlying stealth address and commitment scheme, how the deposit-to-claim flow works at the instruction level, and the exact criteria that gate the subsequent mainnet deployment.
 
 ---
 
@@ -141,7 +141,7 @@ The gate requires all of the following:
 - **Withdrawal coverage:** At least 3 successful `withdraw_private` calls from at least 2 distinct non-team wallets
 - **Refund coverage:** At least 1 successful `authority_refund` — the Phase 3 SENTINEL refund evidence already satisfies this criterion. The refund TX `4YHpsgZpXhvYd9EsCRBjfkhUDgGGitAM3R4gu9EqivtKwMRtamkMN2BUumdZTPbaRt3sQb4mp8QW2YFVZJ2EnYDz` ([Solscan devnet](https://solscan.io/tx/4YHpsgZpXhvYd9EsCRBjfkhUDgGGitAM3R4gu9EqivtKwMRtamkMN2BUumdZTPbaRt3sQb4mp8QW2YFVZJ2EnYDz?cluster=devnet)) confirms the SENTINEL-gated authority refund path works end-to-end. The Phase 3 evidence is committed at `docs/sentinel/evidence/devnet-refund-2026-05-05.json`.
 - **Zero unexplained reverts:** Any revert that cannot be classified as user error within one hour of a human reviewing the failed TX invalidates the gate
-- **Zero authority interventions:** No `set_paused`, no manual fee adjustments, no state corrections from the authority side during the soak window
+- **Zero authority interventions:** No `set_paused`, no manual fee adjustments, no cleanup transactions from the authority side
 
 SENTINEL — documented at https://docs.sip-protocol.org/sipher/sentinel/overview/ — monitors vault state and classifies anomalies in real time. Its advisory mode is live on the current VPS deployment. The gate-check script queries SENTINEL's classification log as part of the "zero unexplained reverts" check.
 


### PR DESCRIPTION
## Summary

- Day 0 announcement post for Sipher Vault devnet beta — explains the privacy primitive (vault breaks the on-chain link between sender wallet and stealth recipient via authority-signed CPI to sip_privacy), walks testers through participating, states gate criteria transparently, sets expectations for the mainnet ship
- Hand-coded architecture SVG showing deposit → withdraw_private → CPI → claim flow, styled for dark backgrounds
- 1696 words, 9 instructions documented in table (matches on-chain reality including `set_paused` added in PR-A1), all 6 gate criteria verbatim from spec D7

## What this PR adds

- `src/content/blog/sipher-vault-devnet-beta-open.md` — the post (announcements category, SIP Protocol Team byline)
- `public/images/sipher-vault/architecture-diagram.svg` — diagram (14KB, hand-coded SVG, viewBox 800×500)

## Spec + plan

- Spec: `docs/superpowers/specs/2026-05-05-phase4-split-devnet-beta-mainnet-design.md` (in sipher repo) — Phase 4a Section, PR-A3 scope
- Plan: `docs/superpowers/plans/2026-05-05-phase4-split-devnet-beta-mainnet.md` (in sipher repo) — Stage A Tasks A3.0 + A3.1

## What this PR explicitly does NOT do

- Does NOT flip the VPS to `SIPHER_NETWORK=devnet` — that is a separate coordinated launch (post merges first, then VPS flip + X thread #1)
- Does NOT publish the Day 7+ mainnet ship post — that is PR-B3 (deferred to gate-pass)
- Does NOT add Mermaid build pipeline to blog-sip Dockerfile — diagram is hand-coded SVG to avoid Chromium dependency

## Verification

- `pnpm build` passes clean
- `pnpm lint` passes
- `pnpm prettier --check src/content/blog/sipher-vault-devnet-beta-open.md` passes
- All 9 instruction names verified against `programs/sipher-vault/programs/sipher-vault/src/lib.rs`
- All gate criteria match spec D7 verbatim
- All cross-links return 200 (sipher.sip-protocol.org, faucet.solana.com, github.com/sip-protocol/sipher/issues, docs.sip-protocol.org/sipher/sentinel/overview/)
- Rendered HTML metadata verified: OG image generated, Twitter card present, JSON-LD structured data present, canonical URL set
- SVG validates as well-formed XML, has `<title>` + `role="img"` + `aria-labelledby` for accessibility

## Test plan

- [x] `pnpm build` clean locally
- [x] Linter passes
- [x] Prettier passes
- [x] All cross-links 200
- [ ] CI green
- [ ] Production deployed
- [ ] `curl -s https://blog.sip-protocol.org/blog/sipher-vault-devnet-beta-open/ | grep -i "Devnet Beta"` returns ≥1 hit

## Coordinated launch sequence (post-merge)

After this PR merges and deploys, the next steps are RECTOR-driven:
1. VPS flip: `sed -i 's/SIPHER_NETWORK=mainnet/SIPHER_NETWORK=devnet/' ~/sipher/.env && sed -i 's/SOLANA_NETWORK=mainnet-beta/SOLANA_NETWORK=devnet/' ~/sipher/.env && cd ~/sipher && docker compose up -d api`
2. Verify `https://sipher.sip-protocol.org/api/config` returns `network: devnet, beta: true`
3. Publish X thread #1, mutual cross-link to this post
4. Day 1-2 tester support
5. Day 3 first gate-check + commit evidence