### PR TITLE
feat: crowds-vs-disguises privacy post + honest comparison fixes

### DIFF
--- a/public/images/crowds-vs-disguises/crowd-vs-disguise.svg
+++ b/public/images/crowds-vs-disguises/crowd-vs-disguise.svg
@@ -60,7 +60,7 @@
   <text x="68" y="546" font-size="15" font-weight="700" fill="#f85149">✗</text>
   <text x="92" y="546" font-size="14" fill="#c9d1d9">no compliance story — can't prove your funds are clean</text>
   <text x="68" y="582" font-size="15" font-weight="700" fill="#f85149">✗</text>
-  <text x="92" y="582" font-size="14" fill="#c9d1d9">flat fee + bps → forces a minimum deposit floor</text>
+  <text x="92" y="582" font-size="14" fill="#c9d1d9">flat fees or fixed pool sizes → minimum deposit floor</text>
 
   <!-- ===== RIGHT CARD: SHIELDED ===== -->
   <rect x="714" y="110" width="650" height="530" rx="14" fill="#161b22" stroke="#30363d"/>
@@ -91,7 +91,7 @@
   <text x="746" y="436" font-size="15" font-weight="700" fill="#3fb950">✓</text>
   <text x="770" y="436" font-size="14" fill="#c9d1d9">identity unlinking is cryptographic — volume-independent</text>
   <text x="746" y="470" font-size="15" font-weight="700" fill="#3fb950">✓</text>
-  <text x="770" y="470" font-size="14" fill="#c9d1d9">amounts hidden at the announcement layer (commitment + headroom)</text>
+  <text x="770" y="470" font-size="14" fill="#c9d1d9">amounts hidden at the announcement layer (pedersen commitment)</text>
   <text x="746" y="504" font-size="15" font-weight="700" fill="#3fb950">✓</text>
   <text x="770" y="504" font-size="14" fill="#c9d1d9">viewing keys: prove clean funds without exposing everything</text>
   <text x="746" y="538" font-size="15" font-weight="700" fill="#3fb950">✓</text>
@@ -99,7 +99,7 @@
 
   <rect x="738" y="560" width="602" height="58" rx="8" fill="#2a2410" stroke="#e3b341"/>
   <text x="752" y="583" font-size="13" font-weight="700" fill="#e3b341">⚠ HONEST: a shielded transfer carries no crowd of its own —</text>
-  <text x="752" y="603" font-size="13" fill="#e3b341">timing set = concurrent shielded txs → app-layer jitter stays mandatory at low volume</text>
+  <text x="752" y="603" font-size="13" fill="#e3b341">timing set = concurrent shielded txs → jitter mandatory at low volume</text>
 
   <!-- ===== BOTTOM BAND ===== -->
   <rect x="36" y="664" width="1328" height="196" rx="14" fill="#161b22" stroke="#4d7c0f"/>

--- a/public/images/crowds-vs-disguises/crowd-vs-disguise.svg
+++ b/public/images/crowds-vs-disguises/crowd-vs-disguise.svg
@@ -1,0 +1,130 @@
+<svg width="1400" height="920" viewBox="0 0 1400 920" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" role="img" aria-label="Mixer pools versus shielded transfers compared across privacy axes">
+  <defs>
+    <marker id="arr-gray" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#8b949e"/>
+    </marker>
+    <marker id="arr-violet" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#a78bfa"/>
+    </marker>
+    <marker id="arr-lime" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#a3e635"/>
+    </marker>
+  </defs>
+
+  <rect width="1400" height="920" fill="#0d1117"/>
+
+  <!-- ===== HEADER ===== -->
+  <text x="700" y="56" text-anchor="middle" font-size="30" font-weight="700" fill="#e6edf3">Mixer Pool vs Shielded — different privacy axes</text>
+  <text x="700" y="86" text-anchor="middle" font-size="15" fill="#9da7b3">two models, two strengths — and the honest gap in each</text>
+
+  <!-- ===== LEFT CARD: MIXER POOL ===== -->
+  <rect x="36" y="110" width="650" height="530" rx="14" fill="#161b22" stroke="#30363d"/>
+  <rect x="56" y="110" width="610" height="4" rx="2" fill="#58a6ff"/>
+  <text x="60" y="152" font-size="20" font-weight="700" fill="#58a6ff">MIXER POOL</text>
+  <text x="662" y="152" text-anchor="end" font-size="13" fill="#9da7b3">the crowd model</text>
+
+  <rect x="60" y="196" width="118" height="34" rx="8" fill="#0d1117" stroke="#30363d"/>
+  <text x="119" y="218" text-anchor="middle" font-size="13" fill="#c9d1d9">user A</text>
+  <rect x="60" y="246" width="118" height="34" rx="8" fill="#0d1117" stroke="#30363d"/>
+  <text x="119" y="268" text-anchor="middle" font-size="13" fill="#c9d1d9">user B</text>
+  <rect x="60" y="296" width="118" height="34" rx="8" fill="#0d1117" stroke="#a3e635"/>
+  <text x="119" y="318" text-anchor="middle" font-size="13" fill="#a3e635">you</text>
+
+  <rect x="240" y="222" width="140" height="82" rx="10" fill="#0d1117" stroke="#58a6ff"/>
+  <text x="310" y="258" text-anchor="middle" font-size="18" font-weight="700" fill="#e6edf3">POOL</text>
+  <text x="310" y="280" text-anchor="middle" font-size="12" fill="#9da7b3">(everyone's funds mixed)</text>
+
+  <line x1="178" y1="213" x2="236" y2="245" stroke="#8b949e" stroke-width="1.5" marker-end="url(#arr-gray)"/>
+  <line x1="178" y1="263" x2="236" y2="263" stroke="#8b949e" stroke-width="1.5" marker-end="url(#arr-gray)"/>
+  <line x1="178" y1="313" x2="236" y2="281" stroke="#8b949e" stroke-width="1.5" marker-end="url(#arr-gray)"/>
+
+  <rect x="420" y="200" width="222" height="46" rx="8" fill="#0d1117" stroke="#30363d"/>
+  <text x="531" y="228" text-anchor="middle" font-size="13" fill="#c9d1d9">relayer + ZK note proof</text>
+  <rect x="420" y="286" width="222" height="46" rx="8" fill="#0d1117" stroke="#a3e635"/>
+  <text x="531" y="305" text-anchor="middle" font-size="13" fill="#a3e635">fresh wallet</text>
+  <text x="531" y="322" text-anchor="middle" font-size="11" fill="#9da7b3">(no link to the deposit)</text>
+  <line x1="380" y1="248" x2="416" y2="230" stroke="#8b949e" stroke-width="1.5" marker-end="url(#arr-gray)"/>
+  <line x1="531" y1="246" x2="531" y2="282" stroke="#8b949e" stroke-width="1.5" marker-end="url(#arr-gray)"/>
+
+  <text x="60" y="364" font-size="13" fill="#9da7b3">the withdrawal proves a deposit exists — never which one</text>
+  <text x="60" y="384" font-size="13" fill="#9da7b3">→ deposit ↔ withdraw link BROKEN · the busier the pool, the stronger</text>
+
+  <line x1="60" y1="404" x2="662" y2="404" stroke="#30363d"/>
+
+  <text x="68" y="438" font-size="15" font-weight="700" fill="#3fb950">✓</text>
+  <text x="92" y="438" font-size="14" fill="#c9d1d9">strong graph break — anonymity set = the pool's volume</text>
+  <text x="68" y="474" font-size="15" font-weight="700" fill="#f85149">✗</text>
+  <text x="92" y="474" font-size="14" fill="#c9d1d9">anonymity is borrowed from other people's volume</text>
+  <text x="68" y="510" font-size="15" font-weight="700" fill="#f85149">✗</text>
+  <text x="92" y="510" font-size="14" fill="#c9d1d9">mixed funds → taint risk at CEX off-ramps</text>
+  <text x="68" y="546" font-size="15" font-weight="700" fill="#f85149">✗</text>
+  <text x="92" y="546" font-size="14" fill="#c9d1d9">no compliance story — can't prove your funds are clean</text>
+  <text x="68" y="582" font-size="15" font-weight="700" fill="#f85149">✗</text>
+  <text x="92" y="582" font-size="14" fill="#c9d1d9">flat fee + bps → forces a minimum deposit floor</text>
+
+  <!-- ===== RIGHT CARD: SHIELDED ===== -->
+  <rect x="714" y="110" width="650" height="530" rx="14" fill="#161b22" stroke="#30363d"/>
+  <rect x="734" y="110" width="610" height="4" rx="2" fill="#a78bfa"/>
+  <text x="738" y="152" font-size="20" font-weight="700" fill="#a78bfa">SHIELDED</text>
+  <text x="1340" y="152" text-anchor="end" font-size="13" fill="#9da7b3">the cryptography model</text>
+
+  <rect x="738" y="210" width="120" height="44" rx="8" fill="#0d1117" stroke="#30363d"/>
+  <text x="798" y="237" text-anchor="middle" font-size="13" fill="#c9d1d9">sender</text>
+  <rect x="1150" y="210" width="190" height="44" rx="8" fill="#0d1117" stroke="#a78bfa"/>
+  <text x="1245" y="228" text-anchor="middle" font-size="13" fill="#e6edf3">stealth address</text>
+  <text x="1245" y="245" text-anchor="middle" font-size="11" fill="#9da7b3">(one-time, no history)</text>
+  <line x1="858" y1="232" x2="1146" y2="232" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#arr-violet)"/>
+  <text x="1002" y="202" text-anchor="middle" font-size="12" fill="#9da7b3">amount → pedersen commitment (in the announcement)</text>
+  <text x="1002" y="272" text-anchor="middle" font-size="12" fill="#9da7b3">ephemeral key: only the recipient can detect &amp; claim</text>
+
+  <rect x="738" y="300" width="140" height="36" rx="8" fill="#0d1117" stroke="#a78bfa"/>
+  <text x="808" y="323" text-anchor="middle" font-size="13" fill="#c9d1d9">viewing key</text>
+  <rect x="1150" y="300" width="190" height="36" rx="8" fill="#0d1117" stroke="#30363d"/>
+  <text x="1245" y="323" text-anchor="middle" font-size="13" fill="#c9d1d9">auditor / CEX</text>
+  <line x1="878" y1="318" x2="1146" y2="318" stroke="#a78bfa" stroke-width="1.5" stroke-dasharray="6 5" marker-end="url(#arr-violet)"/>
+  <text x="1002" y="352" text-anchor="middle" font-size="12" fill="#9da7b3">selective disclosure — open only what's needed</text>
+
+  <text x="738" y="384" font-size="13" fill="#9da7b3">recipient identity unlinked CRYPTOGRAPHICALLY — works at any volume</text>
+
+  <line x1="738" y1="404" x2="1340" y2="404" stroke="#30363d"/>
+
+  <text x="746" y="436" font-size="15" font-weight="700" fill="#3fb950">✓</text>
+  <text x="770" y="436" font-size="14" fill="#c9d1d9">identity unlinking is cryptographic — volume-independent</text>
+  <text x="746" y="470" font-size="15" font-weight="700" fill="#3fb950">✓</text>
+  <text x="770" y="470" font-size="14" fill="#c9d1d9">amounts hidden at the announcement layer (commitment + headroom)</text>
+  <text x="746" y="504" font-size="15" font-weight="700" fill="#3fb950">✓</text>
+  <text x="770" y="504" font-size="14" fill="#c9d1d9">viewing keys: prove clean funds without exposing everything</text>
+  <text x="746" y="538" font-size="15" font-weight="700" fill="#3fb950">✓</text>
+  <text x="770" y="538" font-size="14" fill="#c9d1d9">bps-only fees, no flat fee — no minimum deposit floor</text>
+
+  <rect x="738" y="560" width="602" height="58" rx="8" fill="#2a2410" stroke="#e3b341"/>
+  <text x="752" y="583" font-size="13" font-weight="700" fill="#e3b341">⚠ HONEST: a shielded transfer carries no crowd of its own —</text>
+  <text x="752" y="603" font-size="13" fill="#e3b341">timing set = concurrent shielded txs → app-layer jitter stays mandatory at low volume</text>
+
+  <!-- ===== BOTTOM BAND ===== -->
+  <rect x="36" y="664" width="1328" height="196" rx="14" fill="#161b22" stroke="#4d7c0f"/>
+  <text x="60" y="700" font-size="17" font-weight="700" fill="#a3e635">PICK AXES PER THREAT MODEL → HYBRID IS LEGITIMATE ENGINEERING</text>
+
+  <rect x="60" y="718" width="400" height="118" rx="10" fill="#1c2128" stroke="#30363d"/>
+  <text x="76" y="744" font-size="14" font-weight="700" fill="#a3e635">1 · BOT EVASION (graph + timing)</text>
+  <text x="76" y="768" font-size="12.5" fill="#c9d1d9">route through a crowd, or use a disguise</text>
+  <text x="76" y="786" font-size="12.5" fill="#c9d1d9">+ aggressive jitter, splits, fresh addresses —</text>
+  <text x="76" y="804" font-size="12.5" fill="#c9d1d9">either way: never link wallets directly</text>
+
+  <rect x="486" y="718" width="400" height="118" rx="10" fill="#1c2128" stroke="#30363d"/>
+  <text x="502" y="744" font-size="14" font-weight="700" fill="#a3e635">2 · COMPLIANCE-SENSITIVE FLOWS</text>
+  <text x="502" y="768" font-size="12.5" fill="#c9d1d9">disguise + viewing keys: selective disclosure</text>
+  <text x="502" y="786" font-size="12.5" fill="#c9d1d9">for auditors &amp; off-ramps — something a</text>
+  <text x="502" y="804" font-size="12.5" fill="#c9d1d9">mixer can never offer</text>
+
+  <rect x="912" y="718" width="400" height="118" rx="10" fill="#1c2128" stroke="#a3e635"/>
+  <text x="928" y="744" font-size="14" font-weight="700" fill="#a3e635">3 · WHERE IT CONVERGES</text>
+  <text x="928" y="768" font-size="12.5" fill="#c9d1d9">pooled vault + ZK note withdrawal composed</text>
+  <text x="928" y="786" font-size="12.5" fill="#c9d1d9">with stealth addresses &amp; commitments —</text>
+  <text x="928" y="804" font-size="12.5" fill="#c9d1d9">crowd AND disguise in one stack</text>
+
+  <line x1="462" y1="777" x2="482" y2="777" stroke="#a3e635" stroke-width="2" marker-end="url(#arr-lime)"/>
+  <line x1="888" y1="777" x2="908" y2="777" stroke="#a3e635" stroke-width="2" marker-end="url(#arr-lime)"/>
+
+  <text x="700" y="896" text-anchor="middle" font-size="12" fill="#6e7681">SIP Protocol · blog.sip-protocol.org · sip-protocol.org</text>
+</svg>

--- a/public/images/crowds-vs-disguises/crowd-vs-disguise.svg
+++ b/public/images/crowds-vs-disguises/crowd-vs-disguise.svg
@@ -126,5 +126,5 @@
   <line x1="462" y1="777" x2="482" y2="777" stroke="#a3e635" stroke-width="2" marker-end="url(#arr-lime)"/>
   <line x1="888" y1="777" x2="908" y2="777" stroke="#a3e635" stroke-width="2" marker-end="url(#arr-lime)"/>
 
-  <text x="700" y="896" text-anchor="middle" font-size="12" fill="#6e7681">SIP Protocol · blog.sip-protocol.org · sip-protocol.org</text>
+  <text x="700" y="896" text-anchor="middle" font-size="12" fill="#8b949e">SIP Protocol · blog.sip-protocol.org · sip-protocol.org</text>
 </svg>

--- a/public/images/crowds-vs-disguises/three-shielded-concepts.svg
+++ b/public/images/crowds-vs-disguises/three-shielded-concepts.svg
@@ -137,7 +137,7 @@
   <circle cx="68" cy="1120" r="3" fill="#e3b341"/>
   <text x="84" y="1124" font-size="13.5" fill="#c9d1d9">the threat: deposit &amp; withdraw close in time → matched by pattern</text>
   <circle cx="68" cy="1150" r="3" fill="#e3b341"/>
-  <text x="84" y="1154" font-size="13.5" fill="#c9d1d9">mixers fix this with the pool's crowd; shielded needs concurrent txs</text>
+  <text x="84" y="1154" font-size="13.5" fill="#c9d1d9">mixers blunt this with the pool's crowd; shielded needs concurrent txs</text>
   <circle cx="68" cy="1180" r="3" fill="#e3b341"/>
   <text x="84" y="1184" font-size="13.5" fill="#c9d1d9">every young shielded system is quiet at first → jitter + splits are a must</text>
   <circle cx="68" cy="1210" r="3" fill="#a3e635"/>

--- a/public/images/crowds-vs-disguises/three-shielded-concepts.svg
+++ b/public/images/crowds-vs-disguises/three-shielded-concepts.svg
@@ -1,0 +1,174 @@
+<svg width="1400" height="1380" viewBox="0 0 1400 1380" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" role="img" aria-label="Stealth addresses, Pedersen commitments, and timing correlation explained with analogies">
+  <defs>
+    <marker id="arr-gray" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#8b949e"/>
+    </marker>
+    <marker id="arr-violet" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#a78bfa"/>
+    </marker>
+    <marker id="arr-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#58a6ff"/>
+    </marker>
+  </defs>
+
+  <rect width="1400" height="1380" fill="#0d1117"/>
+
+  <!-- ===== HEADER ===== -->
+  <text x="700" y="54" text-anchor="middle" font-size="28" font-weight="700" fill="#e6edf3">3 Concepts Behind Shielded Transfers — the simple version</text>
+  <text x="700" y="84" text-anchor="middle" font-size="14.5" fill="#9da7b3">stealth addresses · pedersen commitments · timing — companion to “Crowds vs. Disguises”</text>
+
+  <!-- ============ CARD 1 · STEALTH ADDRESS ============ -->
+  <rect x="36" y="108" width="1328" height="388" rx="14" fill="#161b22" stroke="#30363d"/>
+  <rect x="56" y="108" width="1288" height="4" rx="2" fill="#a78bfa"/>
+  <text x="60" y="152" font-size="19" font-weight="700" fill="#a78bfa">1 · STEALTH ADDRESS</text>
+  <text x="310" y="152" font-size="13" fill="#9da7b3">— a new mailbox for every package</text>
+
+  <rect x="60" y="172" width="520" height="104" rx="10" fill="#a78bfa" fill-opacity="0.07" stroke="#a78bfa" stroke-opacity="0.35"/>
+  <text x="76" y="190" font-size="10" font-weight="700" letter-spacing="1.5" fill="#a78bfa">ANALOGY</text>
+  <text x="76" y="210" font-size="13" fill="#c9d1d9">you publish one master address. every time someone sends,</text>
+  <text x="76" y="229" font-size="13" fill="#c9d1d9">the system creates a BRAND-NEW mailbox that only your</text>
+  <text x="76" y="248" font-size="13" fill="#c9d1d9">master key can open. outsiders see thousands of random</text>
+  <text x="76" y="267" font-size="13" fill="#c9d1d9">boxes — no way to tell whose is whose.</text>
+
+  <circle cx="68" cy="304" r="3" fill="#a78bfa"/>
+  <text x="84" y="308" font-size="13.5" fill="#c9d1d9">1 public meta-address → every payment gets a fresh one-time address</text>
+  <circle cx="68" cy="334" r="3" fill="#a78bfa"/>
+  <text x="84" y="338" font-size="13.5" fill="#c9d1d9">no address reuse → addresses can't be linked to each other</text>
+  <circle cx="68" cy="364" r="3" fill="#a78bfa"/>
+  <text x="84" y="368" font-size="13.5" fill="#c9d1d9">only your private key can detect + claim all of them</text>
+  <circle cx="68" cy="394" r="3" fill="#a3e635"/>
+  <text x="84" y="398" font-size="13.5" fill="#a3e635">like rotating wallets — but standardized, and the sender derives them</text>
+
+  <rect x="640" y="196" width="160" height="48" rx="8" fill="#0d1117" stroke="#a78bfa"/>
+  <text x="720" y="216" text-anchor="middle" font-size="13" fill="#e6edf3">meta-address</text>
+  <text x="720" y="233" text-anchor="middle" font-size="10.5" fill="#9da7b3">(public, published once)</text>
+
+  <text x="868" y="166" text-anchor="middle" font-size="11" fill="#9da7b3">+ random ephemeral key (new per payment)</text>
+  <line x1="800" y1="212" x2="936" y2="198" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#arr-violet)"/>
+  <line x1="800" y1="220" x2="936" y2="268" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#arr-violet)"/>
+  <line x1="800" y1="228" x2="936" y2="338" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#arr-violet)"/>
+
+  <rect x="940" y="176" width="170" height="44" rx="8" fill="#0d1117" stroke="#30363d"/>
+  <text x="1025" y="195" text-anchor="middle" font-size="13" font-family="ui-monospace, Menlo, monospace" fill="#e6edf3">7xK4…Qf3a</text>
+  <text x="1025" y="211" text-anchor="middle" font-size="10" fill="#9da7b3">payment #1</text>
+  <rect x="940" y="246" width="170" height="44" rx="8" fill="#0d1117" stroke="#30363d"/>
+  <text x="1025" y="265" text-anchor="middle" font-size="13" font-family="ui-monospace, Menlo, monospace" fill="#e6edf3">9mQ2…Lw8d</text>
+  <text x="1025" y="281" text-anchor="middle" font-size="10" fill="#9da7b3">payment #2</text>
+  <rect x="940" y="316" width="170" height="44" rx="8" fill="#0d1117" stroke="#30363d"/>
+  <text x="1025" y="335" text-anchor="middle" font-size="13" font-family="ui-monospace, Menlo, monospace" fill="#e6edf3">3vF8…Zn5c</text>
+  <text x="1025" y="351" text-anchor="middle" font-size="10" fill="#9da7b3">payment #3</text>
+
+  <rect x="640" y="330" width="160" height="40" rx="8" fill="#0d1117" stroke="#a78bfa"/>
+  <text x="720" y="355" text-anchor="middle" font-size="12.5" fill="#a78bfa">your private key</text>
+  <line x1="800" y1="344" x2="936" y2="212" stroke="#a78bfa" stroke-width="1" stroke-dasharray="4 4" stroke-opacity="0.6"/>
+  <line x1="800" y1="350" x2="936" y2="276" stroke="#a78bfa" stroke-width="1" stroke-dasharray="4 4" stroke-opacity="0.6"/>
+  <line x1="800" y1="356" x2="936" y2="344" stroke="#a78bfa" stroke-width="1" stroke-dasharray="4 4" stroke-opacity="0.6"/>
+  <text x="640" y="392" font-size="11" fill="#a78bfa">detects + claims ALL of the boxes</text>
+
+  <text x="1140" y="240" font-size="12" font-weight="700" fill="#9da7b3">an observer sees:</text>
+  <text x="1140" y="260" font-size="12" fill="#9da7b3">3 random addresses —</text>
+  <text x="1140" y="278" font-size="12" fill="#9da7b3">no visible connection</text>
+
+  <!-- ============ CARD 2 · PEDERSEN COMMITMENT ============ -->
+  <rect x="36" y="516" width="1328" height="388" rx="14" fill="#161b22" stroke="#30363d"/>
+  <rect x="56" y="516" width="1288" height="4" rx="2" fill="#58a6ff"/>
+  <text x="60" y="560" font-size="19" font-weight="700" fill="#58a6ff">2 · PEDERSEN COMMITMENT</text>
+  <text x="360" y="560" font-size="13" fill="#9da7b3">— a tamper-proof sealed envelope</text>
+
+  <rect x="60" y="580" width="520" height="104" rx="10" fill="#58a6ff" fill-opacity="0.07" stroke="#58a6ff" stroke-opacity="0.35"/>
+  <text x="76" y="598" font-size="10" font-weight="700" letter-spacing="1.5" fill="#58a6ff">ANALOGY</text>
+  <text x="76" y="618" font-size="13" fill="#c9d1d9">write the amount on paper → seal it in an envelope.</text>
+  <text x="76" y="637" font-size="13" fill="#c9d1d9">others only see the envelope (hiding). you can't swap</text>
+  <text x="76" y="656" font-size="13" fill="#c9d1d9">the contents after sealing (binding). the magic: two</text>
+  <text x="76" y="675" font-size="13" fill="#c9d1d9">envelopes can be added WITHOUT opening them (homomorphic).</text>
+
+  <circle cx="68" cy="712" r="3" fill="#58a6ff"/>
+  <text x="84" y="716" font-size="13.5" fill="#c9d1d9">hiding: the amount never appears in the announcement</text>
+  <circle cx="68" cy="742" r="3" fill="#58a6ff"/>
+  <text x="84" y="746" font-size="13.5" fill="#c9d1d9">binding: once committed, it can't be quietly changed</text>
+  <circle cx="68" cy="772" r="3" fill="#58a6ff"/>
+  <text x="84" y="776" font-size="13.5" fill="#c9d1d9">homomorphic: totals verify without opening individual amounts</text>
+  <circle cx="68" cy="802" r="3" fill="#a78bfa"/>
+  <text x="84" y="806" font-size="13.5" fill="#a78bfa">viewing key = the official envelope opener → for auditors/CEXs</text>
+
+  <rect x="640" y="604" width="140" height="40" rx="8" fill="#0d1117" stroke="#30363d"/>
+  <text x="710" y="629" text-anchor="middle" font-size="13" font-family="ui-monospace, Menlo, monospace" fill="#e6edf3">100 SOL</text>
+  <rect x="640" y="664" width="140" height="40" rx="8" fill="#0d1117" stroke="#30363d"/>
+  <text x="710" y="689" text-anchor="middle" font-size="11.5" font-family="ui-monospace, Menlo, monospace" fill="#c9d1d9">blinding r (random)</text>
+  <line x1="780" y1="624" x2="826" y2="646" stroke="#8b949e" stroke-width="1.5" marker-end="url(#arr-gray)"/>
+  <line x1="780" y1="684" x2="826" y2="662" stroke="#8b949e" stroke-width="1.5" marker-end="url(#arr-gray)"/>
+
+  <rect x="830" y="624" width="120" height="60" rx="10" fill="#58a6ff" fill-opacity="0.1" stroke="#58a6ff"/>
+  <text x="890" y="652" text-anchor="middle" font-size="14" font-weight="700" fill="#58a6ff">SEAL</text>
+  <text x="890" y="670" text-anchor="middle" font-size="10.5" fill="#9da7b3">(commit)</text>
+  <line x1="950" y1="654" x2="1006" y2="654" stroke="#58a6ff" stroke-width="1.5" marker-end="url(#arr-blue)"/>
+
+  <rect x="1010" y="624" width="220" height="60" rx="8" fill="#0d1117" stroke="#58a6ff"/>
+  <text x="1120" y="650" text-anchor="middle" font-size="13.5" font-family="ui-monospace, Menlo, monospace" fill="#e6edf3">C = 0x02ab…f3</text>
+  <text x="1120" y="670" text-anchor="middle" font-size="10.5" fill="#9da7b3">(all the public ever sees)</text>
+
+  <text x="640" y="740" font-size="13" font-family="ui-monospace, Menlo, monospace" fill="#58a6ff">C = amount·G + blinding·H</text>
+
+  <rect x="640" y="772" width="76" height="36" rx="6" fill="#0d1117" stroke="#30363d"/>
+  <text x="678" y="795" text-anchor="middle" font-size="12.5" font-family="ui-monospace, Menlo, monospace" fill="#c9d1d9">C1</text>
+  <text x="732" y="796" font-size="16" fill="#9da7b3">+</text>
+  <rect x="756" y="772" width="76" height="36" rx="6" fill="#0d1117" stroke="#30363d"/>
+  <text x="794" y="795" text-anchor="middle" font-size="12.5" font-family="ui-monospace, Menlo, monospace" fill="#c9d1d9">C2</text>
+  <text x="848" y="796" font-size="16" fill="#9da7b3">=</text>
+  <rect x="872" y="772" width="120" height="36" rx="6" fill="#0d1117" stroke="#30363d"/>
+  <text x="932" y="795" text-anchor="middle" font-size="12.5" font-family="ui-monospace, Menlo, monospace" fill="#c9d1d9">C1+C2</text>
+  <text x="1010" y="795" font-size="12" fill="#3fb950">✓ the total verifies without opening either one</text>
+
+  <text x="640" y="850" font-size="11.5" fill="#9da7b3">observers see the seal — never the number</text>
+
+  <!-- ============ CARD 3 · TIMING ============ -->
+  <rect x="36" y="924" width="1328" height="388" rx="14" fill="#161b22" stroke="#30363d"/>
+  <rect x="56" y="924" width="1288" height="4" rx="2" fill="#e3b341"/>
+  <text x="60" y="968" font-size="19" font-weight="700" fill="#e3b341">3 · TIMING CORRELATION</text>
+  <text x="340" y="968" font-size="13" fill="#9da7b3">— CCTV doesn't need your face on an empty street</text>
+
+  <rect x="60" y="988" width="520" height="104" rx="10" fill="#e3b341" fill-opacity="0.07" stroke="#e3b341" stroke-opacity="0.35"/>
+  <text x="76" y="1006" font-size="10" font-weight="700" letter-spacing="1.5" fill="#e3b341">ANALOGY</text>
+  <text x="76" y="1026" font-size="13" fill="#c9d1d9">one person enters building A at 03:00, one person exits</text>
+  <text x="76" y="1045" font-size="13" fill="#c9d1d9">building B at 03:05 — CCTV doesn't need a face to guess</text>
+  <text x="76" y="1064" font-size="13" fill="#c9d1d9">they're the same person. a disguise doesn't help here;</text>
+  <text x="76" y="1083" font-size="13" fill="#c9d1d9">what helps: a crowd + random timing.</text>
+
+  <circle cx="68" cy="1120" r="3" fill="#e3b341"/>
+  <text x="84" y="1124" font-size="13.5" fill="#c9d1d9">the threat: deposit &amp; withdraw close in time → matched by pattern</text>
+  <circle cx="68" cy="1150" r="3" fill="#e3b341"/>
+  <text x="84" y="1154" font-size="13.5" fill="#c9d1d9">mixers fix this with the pool's crowd; shielded needs concurrent txs</text>
+  <circle cx="68" cy="1180" r="3" fill="#e3b341"/>
+  <text x="84" y="1184" font-size="13.5" fill="#c9d1d9">every young shielded system is quiet at first → jitter + splits are a must</text>
+  <circle cx="68" cy="1210" r="3" fill="#a3e635"/>
+  <text x="84" y="1214" font-size="13.5" fill="#a3e635">more volume → bigger crowd → correlation gets harder</text>
+
+  <text x="640" y="1006" font-size="12" fill="#a3e635">what apps should do: random delays + splits + round amounts ✓</text>
+
+  <line x1="640" y1="1140" x2="1320" y2="1140" stroke="#30363d" stroke-width="2"/>
+
+  <path d="M 700 1140 Q 745 1092 790 1140" fill="none" stroke="#f85149" stroke-width="1.5" stroke-dasharray="5 4"/>
+  <path d="M 700 1140 Q 890 1038 1080 1140" fill="none" stroke="#3fb950" stroke-width="1.5" stroke-dasharray="5 4"/>
+
+  <circle cx="700" cy="1140" r="7" fill="#e3b341"/>
+  <text x="700" y="1112" text-anchor="middle" font-size="12" fill="#e3b341">deposit</text>
+  <text x="700" y="1166" text-anchor="middle" font-size="10.5" font-family="ui-monospace, Menlo, monospace" fill="#9da7b3">10:00</text>
+
+  <circle cx="790" cy="1140" r="6" fill="#f85149"/>
+  <text x="790" y="1166" text-anchor="middle" font-size="10.5" font-family="ui-monospace, Menlo, monospace" fill="#f85149">10:01 ✗</text>
+  <text x="790" y="1183" text-anchor="middle" font-size="10.5" fill="#f85149">matched</text>
+
+  <circle cx="1080" cy="1140" r="7" fill="#3fb950"/>
+  <text x="890" y="1062" text-anchor="middle" font-size="11.5" fill="#3fb950">random delay (jitter)</text>
+  <text x="1080" y="1166" text-anchor="middle" font-size="10.5" font-family="ui-monospace, Menlo, monospace" fill="#3fb950">16:43 ✓</text>
+  <text x="1080" y="1183" text-anchor="middle" font-size="10.5" fill="#3fb950">+ split 3× at different times</text>
+
+  <circle cx="950" cy="1140" r="4" fill="#6e7681"/>
+  <circle cx="1000" cy="1140" r="4" fill="#6e7681"/>
+  <circle cx="1170" cy="1140" r="4" fill="#6e7681"/>
+  <circle cx="1230" cy="1140" r="4" fill="#6e7681"/>
+  <circle cx="1280" cy="1140" r="4" fill="#6e7681"/>
+  <text x="1115" y="1216" text-anchor="middle" font-size="11" fill="#9da7b3">gray dots = other people's txs — the busier, the safer</text>
+
+  <text x="700" y="1348" text-anchor="middle" font-size="12" fill="#6e7681">infographic #2 — companion to “Crowds vs. Disguises” · SIP Protocol · sip-protocol.org</text>
+</svg>

--- a/public/images/crowds-vs-disguises/three-shielded-concepts.svg
+++ b/public/images/crowds-vs-disguises/three-shielded-concepts.svg
@@ -35,7 +35,7 @@
   <circle cx="68" cy="334" r="3" fill="#a78bfa"/>
   <text x="84" y="338" font-size="13.5" fill="#c9d1d9">no address reuse → addresses can't be linked to each other</text>
   <circle cx="68" cy="364" r="3" fill="#a78bfa"/>
-  <text x="84" y="368" font-size="13.5" fill="#c9d1d9">only your private key can detect + claim all of them</text>
+  <text x="84" y="368" font-size="13.5" fill="#c9d1d9">only your private keys can detect + claim all of them</text>
   <circle cx="68" cy="394" r="3" fill="#a3e635"/>
   <text x="84" y="398" font-size="13.5" fill="#a3e635">like rotating wallets — but standardized, and the sender derives them</text>
 
@@ -59,11 +59,11 @@
   <text x="1025" y="351" text-anchor="middle" font-size="10" fill="#9da7b3">payment #3</text>
 
   <rect x="640" y="330" width="160" height="40" rx="8" fill="#0d1117" stroke="#a78bfa"/>
-  <text x="720" y="355" text-anchor="middle" font-size="12.5" fill="#a78bfa">your private key</text>
+  <text x="720" y="355" text-anchor="middle" font-size="12.5" fill="#a78bfa">your private keys</text>
   <line x1="800" y1="344" x2="936" y2="212" stroke="#a78bfa" stroke-width="1" stroke-dasharray="4 4" stroke-opacity="0.6"/>
   <line x1="800" y1="350" x2="936" y2="276" stroke="#a78bfa" stroke-width="1" stroke-dasharray="4 4" stroke-opacity="0.6"/>
   <line x1="800" y1="356" x2="936" y2="344" stroke="#a78bfa" stroke-width="1" stroke-dasharray="4 4" stroke-opacity="0.6"/>
-  <text x="640" y="392" font-size="11" fill="#a78bfa">detects + claims ALL of the boxes</text>
+  <text x="720" y="392" text-anchor="middle" font-size="11" fill="#a78bfa">detects + claims ALL of the boxes</text>
 
   <text x="1140" y="240" font-size="12" font-weight="700" fill="#9da7b3">an observer sees:</text>
   <text x="1140" y="260" font-size="12" fill="#9da7b3">3 random addresses —</text>
@@ -168,7 +168,7 @@
   <circle cx="1170" cy="1140" r="4" fill="#6e7681"/>
   <circle cx="1230" cy="1140" r="4" fill="#6e7681"/>
   <circle cx="1280" cy="1140" r="4" fill="#6e7681"/>
-  <text x="1115" y="1216" text-anchor="middle" font-size="11" fill="#9da7b3">gray dots = other people's txs — the busier, the safer</text>
+  <text x="1115" y="1216" text-anchor="middle" font-size="11" fill="#9da7b3">gray dots = other txs — the busier, the safer</text>
 
-  <text x="700" y="1348" text-anchor="middle" font-size="12" fill="#6e7681">infographic #2 — companion to “Crowds vs. Disguises” · SIP Protocol · sip-protocol.org</text>
+  <text x="700" y="1348" text-anchor="middle" font-size="12" fill="#8b949e">infographic #2 — companion to “Crowds vs. Disguises” · SIP Protocol · sip-protocol.org</text>
 </svg>

--- a/src/content/blog/crowds-vs-disguises-onchain-privacy.md
+++ b/src/content/blog/crowds-vs-disguises-onchain-privacy.md
@@ -1,7 +1,7 @@
 ---
 title: 'Crowds vs. Disguises: The Two Ways to Be Private On-Chain'
 description: 'Mixers hide you in a crowd; shielded transfers give you a disguise. Four axes of on-chain privacy, what each model protects, and the honest gaps.'
-pubDate: 'Jun 10 2026'
+pubDate: 'Jun 11 2026'
 category: 'thought-leadership'
 tags: ['privacy', 'mixers', 'stealth-addresses', 'pedersen-commitments', 'timing-correlation', 'anonymity-set', 'comparison']
 draft: false
@@ -26,7 +26,7 @@ relatedPosts:
 
 There's a particular kind of trader on Solana who has learned to dread being good at their job: the profitable liquidity provider.
 
-Picture one. She's developed real edge on Meteora DLMM pools — which pairs, which bin ranges, when to reposition. Her positions print. And because every transaction on Solana is public, her edge has become a broadcast. Copy-trade feeds index profitable wallets and republish their entries to subscribers in near real time. Within seconds of every position she opens, mirrored capital crowds into her bins, dilutes her fee capture, and front-runs her exits.
+Picture one. She's developed real edge on Solana DLMM pools — which pairs, which bin ranges, when to reposition. Her positions print. And because every transaction on Solana is public, her edge has become a broadcast. Copy-trade feeds index profitable wallets and republish their entries to subscribers in near real time. Within seconds of every position she opens, mirrored capital crowds into her bins, dilutes her fee capture, and front-runs her exits.
 
 Here's the detail most people miss: **the bots never knew who she was.** They didn't need her name, her Twitter, or her KYC file. They followed *where money moved*. Her wallet address was identity enough.
 
@@ -73,13 +73,13 @@ The shielded model (the family SIP belongs to) takes a different bet: instead of
 
 **Stealth addresses — a new mailbox for every package.** You publish one *meta-address*. Anyone who pays you derives, from it plus a random ephemeral key, a brand-new one-time address that only your private key can detect and claim. A hundred payments to you land on a hundred unconnected addresses. There is nothing to reuse, nothing to profile, and the unlinkability holds even if you're the only user on the network — it's math, not crowd cover.
 
-**Pedersen commitments — a tamper-proof sealed envelope.** Amounts are published as commitments: `C = amount·G + blinding·H`. The envelope *hides* (the amount never appears), *binds* (you can't quietly change the contents after sealing), and — the genuinely magical part — commitments are *homomorphic*: envelopes can be added without opening them, so totals verify while individual amounts stay sealed. Two commitments to the identical amount look completely unrelated, which is why amount-matching attacks that work on pools get nothing here.
+**Pedersen commitments — a tamper-proof sealed envelope.** Amounts are published as commitments: `C = amount·G + blinding·H`. The envelope *hides* (the amount never appears in the announcement), *binds* (you can't quietly change the contents after sealing), and — the genuinely magical part — commitments are *homomorphic*: envelopes can be added without opening them, so totals verify while individual amounts stay sealed. Two commitments to the identical amount look completely unrelated, which is why amount-matching attacks that work on pools get nothing here.
 
 **Viewing keys — the official envelope opener.** Because the envelope has a designated opener, you get something a mixer structurally cannot offer: *selective disclosure*. Hand a viewing key to your auditor, your accountant, or an exchange's compliance desk, and they can verify your flows — read-only, no spending power, and nothing revealed to the rest of the world. Privacy that can prove itself clean.
 
 ![Stealth addresses, Pedersen commitments, and timing correlation explained with analogies](/images/crowds-vs-disguises/three-shielded-concepts.svg)
 
-Identity axis: broken cryptographically. Amount axis: broken cryptographically. Both at any volume, from day one.
+Identity axis: broken cryptographically. Amount axis: sealed cryptographically at the announcement layer. Both at any volume, from day one.
 
 So what's the catch?
 

--- a/src/content/blog/crowds-vs-disguises-onchain-privacy.md
+++ b/src/content/blog/crowds-vs-disguises-onchain-privacy.md
@@ -1,0 +1,130 @@
+---
+title: 'Crowds vs. Disguises: The Two Ways to Be Private On-Chain'
+description: 'Mixers hide you in a crowd; shielded transfers give you a disguise. Four axes of on-chain privacy, what each model protects, and the honest gaps.'
+pubDate: 'Jun 10 2026'
+category: 'thought-leadership'
+tags: ['privacy', 'mixers', 'stealth-addresses', 'pedersen-commitments', 'timing-correlation', 'anonymity-set', 'comparison']
+draft: false
+author: 'SIP Protocol Team'
+tldr: 'Mixer pools hide you in a crowd — privacy scales with volume. Shielded transfers hide you with cryptography — identity and amounts stay private at any volume, but timing needs a crowd or jitter. True of any young shielded system, ours included. Choose by threat model.'
+keyTakeaways:
+  - 'On-chain privacy has four axes: identity, amount, graph, and timing — every system protects only a subset'
+  - 'Mixer pools break the transaction graph with a shared pool + ZK notes; strength = anonymity set = volume'
+  - 'Shielded transfers break identity and amount links cryptographically — guarantees hold at zero volume'
+  - 'A shielded transfer per se carries no crowd: timing correlation is real at low volume — SIP included'
+  - 'Apps should jitter, split, and round amounts regardless of which privacy backend they use'
+  - 'Hybrid routing (crowd + disguise) is legitimate engineering — and where the stack is converging'
+targetAudience: 'DeFi builders, LPs, and crypto users choosing privacy tooling'
+prerequisites:
+  - 'Basic understanding of blockchain transactions'
+relatedPosts:
+  - 'sip-vs-privacycash'
+  - 'understanding-pool-mixing-solana'
+  - 'pedersen-commitments-explained'
+  - 'stealth-addresses-for-humans'
+---
+
+There's a particular kind of trader on Solana who has learned to dread being good at their job: the profitable liquidity provider.
+
+Picture one. She's developed real edge on Meteora DLMM pools — which pairs, which bin ranges, when to reposition. Her positions print. And because every transaction on Solana is public, her edge has become a broadcast. Copy-trade feeds index profitable wallets and republish their entries to subscribers in near real time. Within a few blocks of every position she opens, mirrored capital crowds into her bins, dilutes her fee capture, and front-runs her exits.
+
+Here's the detail most people miss: **the bots never knew who she was.** They didn't need her name, her Twitter, or her KYC file. They followed *where money moved*. Her wallet address was identity enough.
+
+When she goes looking for "privacy," she'll find two very different families of tools, each confidently claiming to fix her problem. They don't do the same thing. Most explanations won't tell her that — so this one will.
+
+## Privacy is four different problems
+
+"Private" sounds like one property. On-chain, it's at least four, and an observer attacks each one separately:
+
+| Axis | The question an observer asks | Example attack |
+|------|-------------------------------|----------------|
+| **Identity** | *Who* is behind this address? | Address reuse links your activity into a profile |
+| **Amount** | *How much* moved? | Matching 1,234.56 in → 1,234.56 out |
+| **Graph** | *Where* did funds come from and go? | Following the money hop by hop |
+| **Timing** | *When* did related things happen? | Deposit at 10:00, withdrawal at 10:01 — probably you |
+
+Every privacy system protects a *subset* of these axes. No deployed system today fully protects all four at once. The two main families — call them **crowds** and **disguises** — pick different subsets, which is exactly why comparing them as "better vs. worse" misses the point.
+
+## Crowds: how mixer pools work
+
+The mixer model (Tornado Cash pioneered it; several Solana protocols run variants today) is a shared pool with a clever exit:
+
+1. Many users deposit into one pool. Funds mingle.
+2. Each deposit records a cryptographic note — a commitment in a Merkle tree.
+3. To withdraw, you present a zero-knowledge proof that says *"I own one of the deposits in this tree"* — without revealing **which one**.
+4. A relayer submits the withdrawal to a fresh address, so even the gas payer doesn't link back to you.
+
+The deposit↔withdraw link is cryptographically severed. That's a genuine break of the **graph** axis, and it's the mixer's superpower.
+
+But notice where the privacy actually comes from: **the crowd.** Your withdrawal could be any of the deposits sitting in the pool — so your protection equals the size and activity of that pool, the *anonymity set*. Ten thousand active deposits: strong. Forty, mostly dormant: an analyst's afternoon project.
+
+That dependency produces the model's well-known costs:
+
+- **Borrowed anonymity.** Your privacy is rented from other people's volume. Quiet pool, weak privacy — nothing you can do about it.
+- **Taint.** The pool mixes everyone's funds, including funds you'd rather not be mixed with. Exchanges and compliance desks treat mixer-sourced deposits with suspicion, and you cannot prove your specific coins are clean — the pool's whole design prevents exactly that.
+- **No selective disclosure.** There is no mechanism to show an auditor your flow without breaking your own privacy entirely.
+- **Fee floors.** Flat relayer fees or fixed pool denominations make small amounts uneconomical, forcing minimum deposit sizes.
+
+![Mixer pools versus shielded transfers compared across privacy axes](/images/crowds-vs-disguises/crowd-vs-disguise.svg)
+
+## Disguises: how shielded transfers work
+
+The shielded model (the family SIP belongs to) takes a different bet: instead of hiding you in a crowd, it makes the observable data **cryptographically meaningless**. Three pieces do the work:
+
+**Stealth addresses — a new mailbox for every package.** You publish one *meta-address*. Anyone who pays you derives, from it plus a random ephemeral key, a brand-new one-time address that only your private key can detect and claim. A hundred payments to you land on a hundred unconnected addresses. There is nothing to reuse, nothing to profile, and the unlinkability holds even if you're the only user on the network — it's math, not crowd cover.
+
+**Pedersen commitments — a tamper-proof sealed envelope.** Amounts are published as commitments: `C = amount·G + blinding·H`. The envelope *hides* (the amount never appears), *binds* (you can't quietly change the contents after sealing), and — the genuinely magical part — commitments are *homomorphic*: envelopes can be added without opening them, so totals verify while individual amounts stay sealed. Two commitments to the identical amount look completely unrelated, which is why amount-matching attacks that work on pools get nothing here.
+
+**Viewing keys — the official envelope opener.** Because the envelope has a designated opener, you get something a mixer structurally cannot offer: *selective disclosure*. Hand a viewing key to your auditor, your accountant, or an exchange's compliance desk, and they can verify your flows — without you exposing anything to the public, and without them getting spending power. Privacy that can prove itself clean.
+
+![Stealth addresses, Pedersen commitments, and timing correlation explained with analogies](/images/crowds-vs-disguises/three-shielded-concepts.svg)
+
+Identity axis: broken cryptographically. Amount axis: broken cryptographically. Both at any volume, from day one.
+
+So what's the catch?
+
+## The honest part: timing
+
+Here is the sentence most privacy marketing won't print: **a shielded transfer, by itself, carries no crowd.**
+
+A disguise is a different kind of protection than a crowd, and the difference shows up on the timing axis. Picture a CCTV operator watching an empty street at 3 AM. One person enters building A at 03:00; one person exits building B at 03:05. The operator doesn't need to see a face to draw the obvious conclusion. A perfect disguise did nothing, because *being the only event in the window* was the identifying signal.
+
+On-chain, the same logic: if a shielded deposit happens and, one minute later, a shielded claim happens — and those are the only two shielded events that hour — an observer doesn't need to break any cryptography to connect them. The timing anonymity set of a shielded system is the set of *concurrent shielded transactions*. A mixer gets its crowd from pooled deposits; a shielded system gets its crowd from traffic.
+
+And every young shielded system starts with thin traffic. **SIP is no exception.** Our identity and amount guarantees don't depend on adoption; our timing privacy does. We'd rather say that plainly than have you discover it in a chain-analysis report.
+
+The good news: timing is the most application-fixable axis there is. Whatever privacy backend you use — pool, shielded, or both — the playbook is the same:
+
+- **Jitter.** Randomize the delay between related operations. Minutes to hours, never a fixed offset.
+- **Split.** Break one logical transfer into several, at different times.
+- **Round.** Use unremarkable amounts; don't move 1,234.56789 twice.
+- **Headroom.** Randomize what's left behind so input and output sums don't reconcile neatly.
+
+If you're building on a shielded system, treat these as mandatory at low volume — and good hygiene forever. As traffic grows, the ambient crowd thickens and timing attacks degrade on their own; jitter just stops being load-bearing.
+
+## Neither model dominates — pick axes per threat
+
+Go back to our LP. Her adversary is a copy-trade bot: it lives on the **graph** and **timing** axes, and it doesn't care about her legal name. Her playbook is fresh addresses for every position, no direct wallet-to-wallet links, and aggressive jitter on funding flows. A crowd serves her; so does a disguise with disciplined timing hygiene. What she should never do is move funds main-wallet → position-wallet in one clean, instant, exact-amount hop — no tool survives that.
+
+Now picture a fund that must answer to auditors, or anyone whose off-ramp is a regulated exchange. Their binding constraint is the **compliance** dimension: they need privacy from the public *and* provability to specific parties. A mixer is actively dangerous for them — it taints their funds and can't generate evidence of innocence. Viewing keys are the entire game.
+
+Different threats, different axes, different right answers. Which is why the developing pattern across serious applications is **hybrid routing**: a crowd where the graph break matters most, a disguise where identity, amounts, and auditability matter most, and timing discipline everywhere. That's not indecision — it's engineering.
+
+## Where this converges
+
+The two models aren't rivals forever; they compose. A pooled vault whose withdrawals are authorized by ZK notes (the crowd) paying out to stealth addresses with committed amounts and viewing-key disclosure (the disguise) covers all four axes plus compliance in one stack. The building blocks already exist in public: ZK funding-proof circuits, and pool-with-verifier deployments running on EVM testnets with gasless relayer exits. Composing them on high-throughput chains is the obvious next chapter for this space — and the direction we're building toward.
+
+## Choosing honestly
+
+If you take one thing from this post: stop asking "which privacy tool is best?" and start asking **"which axes does my threat model need, and which axes does this tool actually cover?"**
+
+And demand the second answer from vendors. A pool should tell you its live anonymity set. A shielded system should tell you its concurrency and what it expects your app to do about timing. Anyone who claims all four axes, at any volume, with no homework left for you — is selling something.
+
+Privacy infrastructure earns trust the same way the rest of cryptography did: by being precise about what it does *not* protect.
+
+## Related reading
+
+- [SIP vs Pool Mixing: The Cryptographic Difference](/blog/sip-vs-privacycash) — the deeper technical comparison
+- [Understanding Pool Mixing on Solana](/blog/understanding-pool-mixing-solana) — the crowd model in detail
+- [Pedersen Commitments Explained](/blog/pedersen-commitments-explained) — the sealed envelope, with math
+- [Stealth Addresses for Humans](/blog/stealth-addresses-for-humans) — the mailbox, gently

--- a/src/content/blog/crowds-vs-disguises-onchain-privacy.md
+++ b/src/content/blog/crowds-vs-disguises-onchain-privacy.md
@@ -26,7 +26,7 @@ relatedPosts:
 
 There's a particular kind of trader on Solana who has learned to dread being good at their job: the profitable liquidity provider.
 
-Picture one. She's developed real edge on Meteora DLMM pools — which pairs, which bin ranges, when to reposition. Her positions print. And because every transaction on Solana is public, her edge has become a broadcast. Copy-trade feeds index profitable wallets and republish their entries to subscribers in near real time. Within a few blocks of every position she opens, mirrored capital crowds into her bins, dilutes her fee capture, and front-runs her exits.
+Picture one. She's developed real edge on Meteora DLMM pools — which pairs, which bin ranges, when to reposition. Her positions print. And because every transaction on Solana is public, her edge has become a broadcast. Copy-trade feeds index profitable wallets and republish their entries to subscribers in near real time. Within seconds of every position she opens, mirrored capital crowds into her bins, dilutes her fee capture, and front-runs her exits.
 
 Here's the detail most people miss: **the bots never knew who she was.** They didn't need her name, her Twitter, or her KYC file. They followed *where money moved*. Her wallet address was identity enough.
 
@@ -56,7 +56,7 @@ The mixer model (Tornado Cash pioneered it; several Solana protocols run variant
 
 The deposit↔withdraw link is cryptographically severed. That's a genuine break of the **graph** axis, and it's the mixer's superpower.
 
-But notice where the privacy actually comes from: **the crowd.** Your withdrawal could be any of the deposits sitting in the pool — so your protection equals the size and activity of that pool, the *anonymity set*. Ten thousand active deposits: strong. Forty, mostly dormant: an analyst's afternoon project.
+But notice where the privacy actually comes from: **the crowd.** Your withdrawal could be any of the deposits sitting in the pool — so your protection equals the size and activity of that pool, the *anonymity set*. Ten thousand active deposits: strong. Forty, mostly dormant: you're exposed.
 
 That dependency produces the model's well-known costs:
 
@@ -75,7 +75,7 @@ The shielded model (the family SIP belongs to) takes a different bet: instead of
 
 **Pedersen commitments — a tamper-proof sealed envelope.** Amounts are published as commitments: `C = amount·G + blinding·H`. The envelope *hides* (the amount never appears), *binds* (you can't quietly change the contents after sealing), and — the genuinely magical part — commitments are *homomorphic*: envelopes can be added without opening them, so totals verify while individual amounts stay sealed. Two commitments to the identical amount look completely unrelated, which is why amount-matching attacks that work on pools get nothing here.
 
-**Viewing keys — the official envelope opener.** Because the envelope has a designated opener, you get something a mixer structurally cannot offer: *selective disclosure*. Hand a viewing key to your auditor, your accountant, or an exchange's compliance desk, and they can verify your flows — without you exposing anything to the public, and without them getting spending power. Privacy that can prove itself clean.
+**Viewing keys — the official envelope opener.** Because the envelope has a designated opener, you get something a mixer structurally cannot offer: *selective disclosure*. Hand a viewing key to your auditor, your accountant, or an exchange's compliance desk, and they can verify your flows — read-only, no spending power, and nothing revealed to the rest of the world. Privacy that can prove itself clean.
 
 ![Stealth addresses, Pedersen commitments, and timing correlation explained with analogies](/images/crowds-vs-disguises/three-shielded-concepts.svg)
 
@@ -98,7 +98,7 @@ The good news: timing is the most application-fixable axis there is. Whatever pr
 - **Jitter.** Randomize the delay between related operations. Minutes to hours, never a fixed offset.
 - **Split.** Break one logical transfer into several, at different times.
 - **Round.** Use unremarkable amounts; don't move 1,234.56789 twice.
-- **Headroom.** Randomize what's left behind so input and output sums don't reconcile neatly.
+- **Headroom.** Leave a random unspent residual behind so input and output amounts never sum cleanly — amount correlation needs neat arithmetic to work.
 
 If you're building on a shielded system, treat these as mandatory at low volume — and good hygiene forever. As traffic grows, the ambient crowd thickens and timing attacks degrade on their own; jitter just stops being load-bearing.
 
@@ -112,7 +112,7 @@ Different threats, different axes, different right answers. Which is why the dev
 
 ## Where this converges
 
-The two models aren't rivals forever; they compose. A pooled vault whose withdrawals are authorized by ZK notes (the crowd) paying out to stealth addresses with committed amounts and viewing-key disclosure (the disguise) covers all four axes plus compliance in one stack. The building blocks already exist in public: ZK funding-proof circuits, and pool-with-verifier deployments running on EVM testnets with gasless relayer exits. Composing them on high-throughput chains is the obvious next chapter for this space — and the direction we're building toward.
+The two models aren't rivals forever; they compose. A pooled vault whose withdrawals are authorized by ZK notes (the crowd) paying out to stealth addresses with committed amounts and viewing-key disclosure (the disguise) covers all four axes plus compliance in one stack. The building blocks already exist in public: ZK funding-proof circuits, on-chain verifiers with gasless relayer exits on EVM testnets, and the stealth-plus-commitment layer already running in production. Composing them on high-throughput chains is the obvious next chapter for this space — and the direction we're building toward.
 
 ## Choosing honestly
 

--- a/src/content/blog/crowds-vs-disguises-onchain-privacy.md
+++ b/src/content/blog/crowds-vs-disguises-onchain-privacy.md
@@ -71,7 +71,7 @@ That dependency produces the model's well-known costs:
 
 The shielded model (the family SIP belongs to) takes a different bet: instead of hiding you in a crowd, it makes the observable data **cryptographically meaningless**. Three pieces do the work:
 
-**Stealth addresses — a new mailbox for every package.** You publish one *meta-address*. Anyone who pays you derives, from it plus a random ephemeral key, a brand-new one-time address that only your private key can detect and claim. A hundred payments to you land on a hundred unconnected addresses. There is nothing to reuse, nothing to profile, and the unlinkability holds even if you're the only user on the network — it's math, not crowd cover.
+**Stealth addresses — a new mailbox for every package.** You publish one *meta-address*. Anyone who pays you derives, from it plus a random ephemeral key, a brand-new one-time address that only your private keys can detect and claim. A hundred payments to you land on a hundred unconnected addresses. There is nothing to reuse, nothing to profile, and the unlinkability holds even if you're the only user on the network — it's math, not crowd cover.
 
 **Pedersen commitments — a tamper-proof sealed envelope.** Amounts are published as commitments: `C = amount·G + blinding·H`. The envelope *hides* (the amount never appears in the announcement), *binds* (you can't quietly change the contents after sealing), and — the genuinely magical part — commitments are *homomorphic*: envelopes can be added without opening them, so totals verify while individual amounts stay sealed. Two commitments to the identical amount look completely unrelated, which is why amount-matching attacks that work on pools get nothing here.
 

--- a/src/content/blog/sip-vs-privacycash.md
+++ b/src/content/blog/sip-vs-privacycash.md
@@ -12,7 +12,7 @@ keyTakeaways:
   - 'Pool mixing privacy depends on anonymity set size; cryptographic privacy is mathematically guaranteed'
   - 'Tornado Nova and Privacy Cash now support arbitrary amounts - but still rely on pool anonymity'
   - 'Amount correlation attacks exploit statistical patterns; Pedersen commitments are cryptographically immune'
-  - 'Pool anonymity sets degrade over time; SIP identity and amount guarantees hold at any adoption level — timing still needs app-layer jitter'
+  - 'Pool anonymity sets degrade over time; SIP identity and amount guarantees hold at any adoption level - timing still needs app-layer jitter'
   - 'Both SIP and Privacy Cash offer compliance paths, but SIP viewing keys provide finer granularity'
   - 'SIP is chain-agnostic; pool mixers are typically single-chain'
 targetAudience: 'Blockchain developers, security researchers, crypto users comparing privacy solutions'
@@ -239,7 +239,7 @@ Even if Alice and Bob commit to the same amount, their commitments are indisting
 | Attack | Pool Mixing Defense | Pedersen Defense |
 |--------|---------------------|------------------|
 | Amount correlation | Statistical (depends on pool size) | Cryptographic (mathematically hidden) |
-| Timing correlation | Mitigated by the pool's crowd (withdrawal delays) | Applies at low volume — mitigate with app-layer jitter |
+| Timing correlation | Mitigated by the pool's crowd (withdrawal delays) | Applies at low volume - mitigate with app-layer jitter |
 | Graph analysis | Broken by the pool (ZK note withdrawal) | Identity unlinked via stealth addresses; the transfer hop itself remains visible |
 
 Pedersen commitments provide **information-theoretic hiding** - even with unlimited computing power and perfect knowledge of the system, the amount cannot be extracted from the commitment alone.

--- a/src/content/blog/sip-vs-privacycash.md
+++ b/src/content/blog/sip-vs-privacycash.md
@@ -2,7 +2,7 @@
 title: 'SIP vs Pool Mixing: The Cryptographic Difference'
 description: 'Pedersen commitments vs pool mixing: why math-based privacy beats crowd-based anonymity. Comparing SIP, Tornado Cash, and Privacy Cash.'
 pubDate: 'Jan 05 2026'
-updatedDate: 'Jun 10 2026'
+updatedDate: 'Jun 11 2026'
 category: 'technical'
 tags: ['privacy', 'pedersen-commitments', 'tornado-cash', 'privacy-cash', 'cryptography', 'comparison']
 draft: false
@@ -110,7 +110,7 @@ Let's be honest about what actually differentiates these approaches:
 
 Pool mixing: Your privacy depends on pool participation. Early pools or unusual amounts have weaker guarantees.
 
-Pedersen: Privacy is cryptographically guaranteed regardless of how many others use the system. 1.5 SOL and 1,000,000 SOL have identical privacy properties.
+Pedersen: Identity and amount privacy are cryptographically guaranteed regardless of how many others use the system. 1.5 SOL and 1,000,000 SOL have identical privacy properties.
 
 ### 2. Homomorphic Properties
 
@@ -157,7 +157,7 @@ The implementations differ, but both acknowledge that "hide everything forever" 
 | Compliance | Selective disclosure | Viewing keys |
 | Homomorphic proofs | No | Yes |
 | Chain support | Single chain | Chain-agnostic |
-| Pool dependency | Yes - privacy scales with usage | No - constant guarantees |
+| Pool dependency | Yes - privacy scales with usage | No - constant identity and amount guarantees |
 | Stealth addresses | No | Yes (EIP-5564) |
 
 ## Amount Correlation Attacks Explained
@@ -257,7 +257,7 @@ For a fuller treatment of which privacy axes each model actually covers - includ
 **Pedersen Commitments (SIP)** excels when:
 - You need provable amount properties (range proofs, balance verification)
 - You're building cross-chain applications
-- You need privacy guarantees independent of adoption
+- You need identity and amount guarantees independent of adoption
 - You want stealth addresses for recipient privacy
 
 ## Security Analysis: Pool Mixing Risks

--- a/src/content/blog/sip-vs-privacycash.md
+++ b/src/content/blog/sip-vs-privacycash.md
@@ -359,8 +359,8 @@ SIP's approach avoids these pool-specific risks:
 | Small anonymity set | Vulnerable | Not applicable (no pool) |
 | Pool fragmentation | Vulnerable | Not applicable |
 | Time degradation | Vulnerable | Not applicable |
-| Graph analysis | Partially vulnerable | Stealth addresses break graphs |
-| Timing attacks | Requires artificial delays | No entry/exit timing |
+| Graph analysis | Partially vulnerable | Stealth addresses unlink identity; transfer hops remain visible |
+| Timing attacks | Requires artificial delays | No pool entry/exit, but low-volume timing needs app-layer jitter |
 | Amount correlation | Statistical defense | Cryptographic defense |
 
 The fundamental difference: SIP's privacy is **deterministic** (guaranteed by cryptography), while pool mixing privacy is **probabilistic** (depends on usage patterns).

--- a/src/content/blog/sip-vs-privacycash.md
+++ b/src/content/blog/sip-vs-privacycash.md
@@ -2,7 +2,7 @@
 title: 'SIP vs Pool Mixing: The Cryptographic Difference'
 description: 'Pedersen commitments vs pool mixing: why math-based privacy beats crowd-based anonymity. Comparing SIP, Tornado Cash, and Privacy Cash.'
 pubDate: 'Jan 05 2026'
-updatedDate: 'Jan 16 2026'
+updatedDate: 'Jun 10 2026'
 category: 'technical'
 tags: ['privacy', 'pedersen-commitments', 'tornado-cash', 'privacy-cash', 'cryptography', 'comparison']
 draft: false
@@ -12,7 +12,7 @@ keyTakeaways:
   - 'Pool mixing privacy depends on anonymity set size; cryptographic privacy is mathematically guaranteed'
   - 'Tornado Nova and Privacy Cash now support arbitrary amounts - but still rely on pool anonymity'
   - 'Amount correlation attacks exploit statistical patterns; Pedersen commitments are cryptographically immune'
-  - 'Pool anonymity sets degrade over time; SIP privacy is constant regardless of adoption'
+  - 'Pool anonymity sets degrade over time; SIP identity and amount guarantees hold at any adoption level — timing still needs app-layer jitter'
   - 'Both SIP and Privacy Cash offer compliance paths, but SIP viewing keys provide finer granularity'
   - 'SIP is chain-agnostic; pool mixers are typically single-chain'
 targetAudience: 'Blockchain developers, security researchers, crypto users comparing privacy solutions'
@@ -239,10 +239,12 @@ Even if Alice and Bob commit to the same amount, their commitments are indisting
 | Attack | Pool Mixing Defense | Pedersen Defense |
 |--------|---------------------|------------------|
 | Amount correlation | Statistical (depends on pool size) | Cryptographic (mathematically hidden) |
-| Timing correlation | Requires delay, reduces UX | Not applicable (no pool entry/exit) |
-| Graph analysis | Breaks with mixing | Not applicable (stealth addresses) |
+| Timing correlation | Mitigated by the pool's crowd (withdrawal delays) | Applies at low volume — mitigate with app-layer jitter |
+| Graph analysis | Broken by the pool (ZK note withdrawal) | Identity unlinked via stealth addresses; the transfer hop itself remains visible |
 
 Pedersen commitments provide **information-theoretic hiding** - even with unlimited computing power and perfect knowledge of the system, the amount cannot be extracted from the commitment alone.
+
+For a fuller treatment of which privacy axes each model actually covers - including an honest look at timing - see [Crowds vs. Disguises: The Two Ways to Be Private On-Chain](/blog/crowds-vs-disguises-onchain-privacy).
 
 ## When to Use What
 


### PR DESCRIPTION
## Summary

New thought-leadership post **"Crowds vs. Disguises: The Two Ways to Be Private On-Chain"** — the honest multi-axis privacy framing (identity / amount / graph / timing), with two new infographics. Also corrects misleading rows in the existing `sip-vs-privacycash` comparison post.

## Changes

- `src/content/blog/crowds-vs-disguises-onchain-privacy.md` — new post (thought-leadership)
- `public/images/crowds-vs-disguises/` — 2 self-contained dark SVG infographics
- `src/content/blog/sip-vs-privacycash.md` — honest fixes: both tables ("Not applicable" timing/graph rows → honest versions; architectural-advantages table aligned), scoped key takeaway + 3 residual absolute-constancy claims, cross-link to the new post, `updatedDate`

## Verification

- `pnpm build` green (schema-validated frontmatter, routes, both SVGs in dist)
- No volume statistics in the honest-timing section (grep gate)
- Privacy gates clean across every changed file
- Each artifact passed spec-compliance + quality review with fix loops, plus a final whole-branch review